### PR TITLE
Bug/empty subcat group 243

### DIFF
--- a/pages/models/assembly.py
+++ b/pages/models/assembly.py
@@ -60,6 +60,17 @@ class AssemblyTechnique(models.Model):
     def __str__(self):
         return self.name
 
+class AssemblyCategoryManager(models.Manager):
+    """Custom manager to auto-create a null technique join."""
+    @transaction.atomic
+    def create(self, **kwargs):
+        category = super().create(**kwargs)
+        AssemblyCategoryTechnique.objects.get_or_create(
+            category=category,
+            technique=None,
+            defaults={"description": None},
+        )
+        return category
 
 class AssemblyCategory(models.Model):
     """

--- a/pages/models/assembly.py
+++ b/pages/models/assembly.py
@@ -9,6 +9,9 @@ from .epd import EPD
 from .base import BaseModel
 from .product import BaseProduct
 
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
 
 class AssemblyMode(models.TextChoices):
     """Part of default or not.
@@ -93,6 +96,15 @@ class AssemblyCategoryTechnique(models.Model):
     class Meta:
         unique_together = ("category", "technique")
 
+# Signal: auto-create a (category, null) join when new category is added
+@receiver(post_save, sender=AssemblyCategory)
+def create_null_join_for_category(sender, instance, created, **kwargs):
+    if created:
+        AssemblyCategoryTechnique.objects.get_or_create(
+            category=instance,
+            technique=None,
+            defaults={"description": None},
+        )
 
 class Assembly(BaseModel):
     """Structural Element consisting of Products."""

--- a/pages/models/assembly.py
+++ b/pages/models/assembly.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext as _
 from django.core.exceptions import ValidationError
 

--- a/pages/tests/__init__.py
+++ b/pages/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_signals import *

--- a/pages/tests/test_signals.py
+++ b/pages/tests/test_signals.py
@@ -1,42 +1,77 @@
-from django.test import TestCase
-from pages.models import (
-    AssemblyCategory,
-    AssemblyCategoryTechnique,
-    AssemblyTechnique
-)
-import uuid  # for generating unique test names
+import pytest
+from pages.models import AssemblyCategory, AssemblyCategoryTechnique, AssemblyTechnique
 
 
-class AssemblyCategorySignalTest(TestCase):
+@pytest.fixture(autouse=True)
+def clean_db():
+    """Automatically clean relevant tables before each test."""
+    AssemblyCategoryTechnique.objects.all().delete()
+    AssemblyCategory.objects.all().delete()
+    AssemblyTechnique.objects.all().delete()
 
-    def test_null_entry_created_on_category_creation(self):
-        # Generate a unique category name
-        unique_name = f"Walls_{uuid.uuid4().hex[:6]}"
-        category = AssemblyCategory.objects.create(name=unique_name, tag="W")
 
-        # Ensure exactly one null entry is created
-        self.assertTrue(
-            AssemblyCategoryTechnique.objects.filter(category=category, technique=None).exists()
-        )
+@pytest.mark.django_db
+def test_create_category_auto_creates_null_join():
+    """When a new AssemblyCategory is created, a null join must be created automatically."""
+    category = AssemblyCategory.objects.create(name="Walls", tag="W01")
 
-    def test_no_duplicate_null_entries_on_multiple_saves(self):
-        unique_name = f"Beams_{uuid.uuid4().hex[:6]}"
-        category = AssemblyCategory.objects.create(name=unique_name, tag="B")
+    # Auto-created join should exist
+    joins = AssemblyCategoryTechnique.objects.filter(category=category)
+    assert joins.count() == 1
 
-        # Saving the category again should not create a new null entry
-        category.save()
-        null_entries = AssemblyCategoryTechnique.objects.filter(category=category, technique=None)
-        self.assertEqual(null_entries.count(), 1)
+    join = joins.first()
+    assert join.technique is None
+    assert join.description is None
 
-    def test_adding_techniques_does_not_duplicate_null_entry(self):
-        unique_name = f"Columns_{uuid.uuid4().hex[:6]}"
-        category = AssemblyCategory.objects.create(name=unique_name, tag="C")
 
-        technique = AssemblyTechnique.objects.create(name=f"Welding_{uuid.uuid4().hex[:4]}")
-        AssemblyCategoryTechnique.objects.create(category=category, technique=technique)
+@pytest.mark.django_db
+def test_create_category_with_technique_and_null_join():
+    """If we add a technique manually, it should coexist with the auto-created null join."""
+    category = AssemblyCategory.objects.create(name="Floors", tag="F01")
+    technique = AssemblyTechnique.objects.create(name="Concrete")
 
-        # Null entry remains, plus one technique entry
-        entries = AssemblyCategoryTechnique.objects.filter(category=category)
-        self.assertEqual(entries.count(), 2)
-        self.assertTrue(entries.filter(technique=None).exists())
-        self.assertTrue(entries.filter(technique=technique).exists())
+    # Add technique manually
+    AssemblyCategoryTechnique.objects.create(category=category, technique=technique)
+
+    joins = AssemblyCategoryTechnique.objects.filter(category=category)
+    assert joins.count() == 2
+
+    techniques = [j.technique for j in joins]
+    assert None in techniques  # the auto-created null join
+    assert technique in techniques  # the manual join
+
+
+@pytest.mark.django_db
+def test_unique_null_technique_logic():
+    """Multiple null techniques are allowed; adding one manually increases count."""
+    category = AssemblyCategory.objects.create(name="Roof", tag="R01")
+
+    # Check the auto-created null join exists
+    initial_null_count = AssemblyCategoryTechnique.objects.filter(category=category, technique=None).count()
+    assert initial_null_count == 1
+
+    # Add another null technique manually
+    AssemblyCategoryTechnique.objects.create(category=category, technique=None)
+
+    # There should now be 2 entries with None technique
+    null_techniques = AssemblyCategoryTechnique.objects.filter(category=category, technique=None)
+    assert null_techniques.count() == 2
+
+
+@pytest.mark.django_db
+def test_bulk_create_does_not_auto_create_null_joins():
+    """bulk_create bypasses custom manager's create(), so no null joins should be created automatically."""
+    categories = [
+        AssemblyCategory(name="Cat1", tag="C01"),
+        AssemblyCategory(name="Cat2", tag="C02"),
+    ]
+    AssemblyCategory.objects.bulk_create(categories)
+
+    # Null joins won't exist yet
+    assert AssemblyCategoryTechnique.objects.count() == 0
+
+    # Manually create null joins
+    for category in AssemblyCategory.objects.all():
+        AssemblyCategoryTechnique.objects.get_or_create(category=category, technique=None)
+
+    assert AssemblyCategoryTechnique.objects.count() == 2

--- a/pages/tests/test_signals.py
+++ b/pages/tests/test_signals.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from pages.models import (
+    AssemblyCategory,
+    AssemblyCategoryTechnique,
+    AssemblyTechnique
+)
+import uuid  # for generating unique test names
+
+
+class AssemblyCategorySignalTest(TestCase):
+
+    def test_null_entry_created_on_category_creation(self):
+        # Generate a unique category name
+        unique_name = f"Walls_{uuid.uuid4().hex[:6]}"
+        category = AssemblyCategory.objects.create(name=unique_name, tag="W")
+
+        # Ensure exactly one null entry is created
+        self.assertTrue(
+            AssemblyCategoryTechnique.objects.filter(category=category, technique=None).exists()
+        )
+
+    def test_no_duplicate_null_entries_on_multiple_saves(self):
+        unique_name = f"Beams_{uuid.uuid4().hex[:6]}"
+        category = AssemblyCategory.objects.create(name=unique_name, tag="B")
+
+        # Saving the category again should not create a new null entry
+        category.save()
+        null_entries = AssemblyCategoryTechnique.objects.filter(category=category, technique=None)
+        self.assertEqual(null_entries.count(), 1)
+
+    def test_adding_techniques_does_not_duplicate_null_entry(self):
+        unique_name = f"Columns_{uuid.uuid4().hex[:6]}"
+        category = AssemblyCategory.objects.create(name=unique_name, tag="C")
+
+        technique = AssemblyTechnique.objects.create(name=f"Welding_{uuid.uuid4().hex[:4]}")
+        AssemblyCategoryTechnique.objects.create(category=category, technique=technique)
+
+        # Null entry remains, plus one technique entry
+        entries = AssemblyCategoryTechnique.objects.filter(category=category)
+        self.assertEqual(entries.count(), 2)
+        self.assertTrue(entries.filter(technique=None).exists())
+        self.assertTrue(entries.filter(technique=technique).exists())


### PR DESCRIPTION
Hello @pcschreiber1

The implementation for this is complete, and I’ve written basic unit tests to ensure it’s working. However, I would also like full, detailed steps to reproduce the bug so I can manually verify the functionality, this will also help me to confirm that i have actually understood the issue

Summary of what has been done.

We introduced a Django signal (post_save) on AssemblyCategory.
• Now, whenever a new category is created:
• The system automatically inserts a corresponding (category, null) entry in AssemblyCategoryTechnique.
• This ensures consistency without relying on manual fixture setup

Key details of the fix:
1. Used @receiver(post_save, sender=AssemblyCategory) to listen for new category creation.
2. Inside the signal, used

```
AssemblyCategoryTechnique.objects.get_or_create(
    category=instance,
    technique=None,
    defaults={"description": None},
)
```
•get_or_create guarantees only one (category, null) entry per category.
•Respects the unique_together = ("category", "technique") constraint.