### PR TITLE
218-simulation-looses-real-elements

### DIFF
--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -11,6 +11,8 @@
     <p class="text-muted">{{ building.country }}</p>
   </div>
   <!-- Buttons -->
+  {% comment %}
+  Simulation button temporarily disabled due to bug where original components were being removed
   {% if building_id %}
   <div class="col-auto">
     <div class="d-flex pt-2">
@@ -26,6 +28,7 @@
     </div>
   </div>
   {% endif %}
+  {% endcomment %}
 </div>
 
 {% include "pages/building/building_core.html" %}


### PR DESCRIPTION
# Disable Simulation Button to Prevent Component Loss
  
**Closes #218**

## What this does

Temporarily disabled the simulation button to prevent the bug where original building components were being removed during simulation operations.

## Main features
  - Simulation button is commented out in building template
  - Users cannot accidentally trigger the problematic simulation feature
  - All simulation functionality preserved in code for future bug fix
  - Explanatory comment added

## Files changed
  - templates/pages/building/building.html
  - Commented out simulation button with bug explanation
  
  ## Testing

<img width="1316" height="279" alt="image" src="https://github.com/user-attachments/assets/0b3806b0-8fbb-4c5b-91ca-567197db39f0" />

<img width="1290" height="337" alt="image" src="https://github.com/user-attachments/assets/3cf557e5-47d0-4df0-bd59-91a5679f9c7a" />

