### PR TITLE
267-make-life-span-field-optional-in-component-editor

### DIFF
--- a/pages/forms/assembly_form.py
+++ b/pages/forms/assembly_form.py
@@ -75,15 +75,15 @@ class AssemblyForm(forms.ModelForm):
         max_digits=10,
         widget=forms.NumberInput(attrs={"class": "form-control", "type": "number"}),
     )
-    reporting_life_cycle = forms.IntegerField(
-        label="Life Span",
-        min_value=1,
-        max_value=10000,
-        help_text="Report in years",
-        required=True,
-        initial=50,
-        widget=forms.NumberInput(attrs={"class": "form-control", "type": "number"}),
-    )
+    # reporting_life_cycle = forms.IntegerField(
+    #     label="Life Span",
+    #     min_value=1,
+    #     max_value=10000,
+    #     help_text="Report in years",
+    #     required=True,
+    #     initial=50,
+    #     widget=forms.NumberInput(attrs={"class": "form-control", "type": "number"}),
+    # )
 
     class Meta:
         model = Assembly
@@ -120,11 +120,11 @@ class AssemblyForm(forms.ModelForm):
             self.fields["quantity"].initial = BuildingAssemblyModel.objects.get(
                 assembly=self.instance, building__pk=building_id
             ).quantity
-            self.fields["reporting_life_cycle"].initial = (
-                BuildingAssemblyModel.objects.get(
-                    assembly=self.instance, building__pk=building_id
-                ).reporting_life_cycle
-            )
+            # self.fields["reporting_life_cycle"].initial = (
+            #     BuildingAssemblyModel.objects.get(
+            #         assembly=self.instance, building__pk=building_id
+            #     ).reporting_life_cycle
+            # )
         else:
             self.fields["mode"].initial = AssemblyMode.CUSTOM
             self.fields["dimension"].initial = AssemblyDimension.AREA

--- a/pages/forms/boq_assembly_form.py
+++ b/pages/forms/boq_assembly_form.py
@@ -11,15 +11,15 @@ class BOQAssemblyForm(forms.ModelForm):
         widget=widgets.Textarea(attrs={"rows": 2}), required=False
     )
 
-    reporting_life_cycle = forms.IntegerField(
-        label="Life Span",
-        min_value=1,
-        max_value=10000,
-        help_text="Report in years",
-        required=True,
-        initial=50,
-        widget=forms.NumberInput(attrs={"class": "form-control", "type": "number"}),
-    )
+    # reporting_life_cycle = forms.IntegerField(
+    #     label="Life Span",
+    #     min_value=1,
+    #     max_value=10000,
+    #     help_text="Report in years",
+    #     required=True,
+    #     initial=50,
+    #     widget=forms.NumberInput(attrs={"class": "form-control", "type": "number"}),
+    # )
 
     class Meta:
         model = Assembly
@@ -38,8 +38,9 @@ class BOQAssemblyForm(forms.ModelForm):
 
         super().__init__(*args, **kwargs)
         if kwargs.get("instance"):
-            self.fields["reporting_life_cycle"].initial = (
-                BuildingAssemblyModel.objects.get(
-                    assembly=self.instance, building__pk=building_id
-                ).reporting_life_cycle
-            )
+            pass
+            # self.fields["reporting_life_cycle"].initial = (
+            #     BuildingAssemblyModel.objects.get(
+            #         assembly=self.instance, building__pk=building_id
+            #     ).reporting_life_cycle
+            # )

--- a/pages/views/assembly/save_to_assembly.py
+++ b/pages/views/assembly/save_to_assembly.py
@@ -72,8 +72,8 @@ def save_assembly(
                         "quantity", 1
                     ),  # Get quantity from POST data
                     "reporting_life_cycle": request.POST.get(
-                        "reporting_life_cycle"
-                    ),  # Get reporting_life_cycle from POST data
+                        "reporting_life_cycle", 50
+                    ),  # Get reporting_life_cycle from POST data, default to 50
                 },
             )
         else:

--- a/templates/pages/assembly/assembly.html
+++ b/templates/pages/assembly/assembly.html
@@ -44,7 +44,8 @@
                     {{ form.dimension }}
                     </div>
                 </div>
-                <div class="col-md-5">
+                <!-- Life-span field removed as per issue #267 -->
+                <!-- <div class="col-md-5">
                     <label for="{{ form.reporting_life_cycle.id_for_label }}" class="form-label">
                         {{ form.reporting_life_cycle.label }}*
                     </label>
@@ -52,7 +53,7 @@
                         {{ form.reporting_life_cycle }}
                         <span class="input-group-text" id="reporting_life_cycle_addon">years</span>
                     </div>
-                </div>
+                </div> -->
             </div>
         </div>
         <div class="col-6">

--- a/templates/pages/assembly/boq.html
+++ b/templates/pages/assembly/boq.html
@@ -18,7 +18,8 @@
       <div class="col-md-6">
           {{ form.name |as_crispy_field }}
       </div>
-      <div class="col-md-6">
+      <!-- Life-span field removed as per issue #267 -->
+      <!-- <div class="col-md-6">
         <label for="{{ form.reporting_life_cycle.id_for_label }}" class="form-label">
             {{ form.reporting_life_cycle.label }}*
         </label>
@@ -26,7 +27,7 @@
             {{ form.reporting_life_cycle }}
             <span class="input-group-text" id="reporting_life_cycle_addon">years</span>
         </div>
-      </div>
+      </div> -->
     </div>
     
     <div class="row">


### PR DESCRIPTION
# Remove Mandatory Life-Span Field from Component Editor

**Closes #267**

## What this does
Removes the mandatory life-span field from the Component Editor forms to reduce the number of required fields users must fill out, improving user experience while maintaining system functionality.

## Main features
 - Commented out `reporting_life_cycle` field in `AssemblyForm` and `BOQAssemblyForm`
 - Commented out related field initialization code in both forms
 - Removed UI elements (labels, input fields, "years" text) from templates
 - Added default value of 50 years in save logic to maintain database integrity
 - Added `pass` statements to maintain proper Python syntax
 - Field code preserved as comments for future reference

## Files changed
 - `pages/forms/assembly_form.py`
 - `pages/forms/boq_assembly_form.py`
 - `pages/views/assembly/save_to_assembly.py`
 - `templates/pages/assembly/assembly.html`
 - `templates/pages/assembly/boq.html`

## Testing

<img width="1232" height="495" alt="image" src="https://github.com/user-attachments/assets/78a3e815-489e-487f-849f-fee13736d324" />


<img width="1238" height="777" alt="image" src="https://github.com/user-attachments/assets/226a0ec8-a990-42fe-9b6d-7b7f9dc29400" />
