### PR TITLE
285-bug-cookie-modal-does-not-apply-settings

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -266,42 +266,42 @@
       fetch('{% url "cookie_groups" %}')
         .then(response => response.json())
         .then(data => {
-          const promises = [];
-          
-          data.groups.forEach(group => {
-            const checkbox = document.getElementById(`cookie-${group.id}`);
-            if (checkbox) {
-              const isEnabled = group.required ? true : checkbox.checked;
-              const url = isEnabled ? `/cookies/accept/${group.id}/` : `/cookies/decline/${group.id}/`;
-              
-              promises.push(
-                fetch(url, {
+          return data.groups.reduce((promise, group) => {
+            return promise.then((results) => {
+              const checkbox = document.getElementById(`cookie-${group.id}`);
+              if (checkbox) {
+                const isEnabled = group.required ? true : checkbox.checked;
+                const url = isEnabled ? `/cookies/accept/${group.id}/` : `/cookies/decline/${group.id}/`;
+
+                return fetch(url, {
                   method: 'POST',
                   headers: {
                     'X-CSRFToken': '{{ csrf_token }}',
                     'Content-Type': 'application/x-www-form-urlencoded',
                   }
-                })
-              );
-            }
-          });
-
-          return Promise.all(promises);
+                }).then(response => {
+                  if (!response.ok) {
+                    console.error(`Failed to save ${group.id} cookie setting:`, response.status);
+                    throw new Error(`Failed to save ${group.id} cookie setting`);
+                  }
+                  return [...results, response];
+                });
+              }
+              return results;
+            });
+          }, Promise.resolve([]));
         })
         .then(responses => {
-          const allOk = responses.every(response => response.ok);
-          if (allOk) {
-            setBannerShownCookie();
-            hideCookieBanner();
-            const modal = bootstrap.Modal.getInstance(document.getElementById('cookieSettingsModal'));
-            if (modal) modal.hide();
-            setTimeout(() => location.reload(), 300);
-          } else {
-            console.error('Some cookie settings failed to save');
-          }
+          console.log('All cookie settings saved successfully');
+          setBannerShownCookie();
+          hideCookieBanner();
+          const modal = bootstrap.Modal.getInstance(document.getElementById('cookieSettingsModal'));
+          if (modal) modal.hide();
+          setTimeout(() => location.reload(), 500);
         })
         .catch(error => {
           console.error('Error saving cookie settings:', error);
+          alert('Failed to save cookie preferences. Please try again.');
         });
     }
 


### PR DESCRIPTION
# Fix Cookie Modal Settings Not Being Applied

  Closes #285

## What this does

Fixes a bug where the cookie modal's "Save Preferences" button did not properly apply cookie settings, causing media content (like YouTube videos) to remain blocked even after enabling the required cookies through the modal.

## Main features

 - Sequential Processing: Changed from parallel Promise.all() to sequential reduce() pattern to prevent race conditions when saving multiple cookie preferences
 - Better Error Handling: Added proper error checking with user feedback via alerts when cookie settings fail to save
 - Improved Timing: Increased page reload timeout from 300ms to 500ms to ensure server has processed all cookie changes

## Files changed

 - templates/_base.html - Modified saveCustomSettings() JavaScript function to process cookie preferences sequentially instead of in parallel, preventing the race condition that caused inconsistent saving behavior
