### PR TITLE
297-ensure-that-empty-subcategory-is-created-on-save-not-on-create-only

### DIFF
--- a/pages/models/assembly.py
+++ b/pages/models/assembly.py
@@ -107,15 +107,15 @@ class AssemblyCategoryTechnique(models.Model):
     class Meta:
         unique_together = ("category", "technique")
 
-# Signal: auto-create a (category, null) join when new category is added
+# Signal: auto-create a (category, null) join when category is saved
 @receiver(post_save, sender=AssemblyCategory)
 def create_null_join_for_category(sender, instance, created, **kwargs):
-    if created:
-        AssemblyCategoryTechnique.objects.get_or_create(
-            category=instance,
-            technique=None,
-            defaults={"description": None},
-        )
+    # Always ensure empty subcategory exists, not just on creation
+    AssemblyCategoryTechnique.objects.get_or_create(
+        category=instance,
+        technique=None,
+        defaults={"description": None},
+    )
 
 class Assembly(BaseModel):
     """Structural Element consisting of Products."""


### PR DESCRIPTION
# Ensure Empty Subcategory Created on Save for Assembly Categories

  Closes #297

# What this does

Fixes a bug where existing Assembly Categories did not have an empty subcategory (technique=None) because the creation logic only ran on initial creation, not on subsequent saves. This caused issues for categories that existed before the auto-creation logic was implemented.

 ## Main features
  - Auto-create on Every Save: Modified post_save signal to ensure empty subcategory exists on every save, not just creation
  - Backward Compatibility: Automatically fixes existing categories when they are updated by admins
  - No Duplicates: Uses get_or_create to prevent duplicate empty subcategories
    
  ## Files changed
  - `pages/models/assembly.py` - Modified the `create_null_join_for_category` signal to remove the `if created` check, ensuring empty subcategories are created on every save operation
