### PR TITLE
125-clear-button-search-modal

### DIFF
--- a/templates/pages/assembly/epd_list.html
+++ b/templates/pages/assembly/epd_list.html
@@ -4,27 +4,63 @@
 
 {% comment %} FILTERS {% endcomment %}
 {% if assembly_id %}
-<form 
+<form id="epd-filter-form"
     {% if is_boq %}
     hx-post="{% url 'boq_edit' building_id=building_id assembly_id=assembly_id %}?simulation={{simulation}}"
     {% else %}
     hx-post="{% url 'component_edit' building_id=building_id assembly_id=assembly_id %}?simulation={{simulation}}"
-    {% endif %}  
-    hx-target="#epd-list" 
+    {% endif %}
+    hx-target="#epd-list"
     hx-vals='{"action": "filter", "dimension": "{{dimension}}" }'>
 {% else %}
-<form 
+<form id="epd-filter-form"
     {% if is_boq %}
     hx-post="{% url 'boq' building_id=building_id %}?simulation={{simulation}}"
     {% else %}
     hx-post="{% url 'component' building_id=building_id %}?simulation={{simulation}}"
     {% endif %}
-    hx-target="#epd-list" 
+    hx-target="#epd-list"
     hx-vals='{"action": "filter", "dimension": "{{dimension}}" }'>
 {% endif %}
     <!-- Create an identifier for this post request -->
     {% crispy epd_filters_form %}
-</form> 
+    <div class="d-flex justify-content-end mt-3">
+        <button type="button"
+                class="btn btn-outline-secondary btn-sm"
+                onclick="clearEpdFilters()">
+            <i class="fas fa-times me-1"></i>Clear All Filters
+        </button>
+    </div>
+</form>
+
+<script>
+function clearEpdFilters() {
+    const form = document.getElementById('epd-filter-form');
+
+    // Clear all input fields
+    const inputs = form.querySelectorAll('input[type="text"], input[type="search"]');
+    inputs.forEach(input => {
+        input.value = '';
+    });
+
+    // Reset all select dropdowns to first option
+    const selects = form.querySelectorAll('select');
+    selects.forEach(select => {
+        select.selectedIndex = 0;
+    });
+
+    // Trigger HTMX request to reload data with cleared filters
+    htmx.ajax('POST', form.getAttribute('hx-post'), {
+        target: form.getAttribute('hx-target'),
+        swap: 'innerHTML',
+        values: {
+            'csrfmiddlewaretoken': form.querySelector('[name="csrfmiddlewaretoken"]').value,
+            'action': 'filter',
+            'dimension': form.querySelector('[name="dimension"]') ? form.querySelector('[name="dimension"]').value : ''
+        }
+    });
+}
+</script> 
 
 {% comment %} EPD LIST {% endcomment %}
 <ul class="list-group mt-3">

--- a/templates/pages/assembly/templates_list.html
+++ b/templates/pages/assembly/templates_list.html
@@ -13,13 +13,49 @@
         </p>
         
         <!-- Filter Form -->
-        <form hx-post="{% url 'assembly_templates' building_id=building_id %}?simulation={{ simulation }}"
-              hx-target="#template-cards" 
-              hx-vals='{"action": "filter"}' 
+        <form id="template-filter-form"
+              hx-post="{% url 'assembly_templates' building_id=building_id %}?simulation={{ simulation }}"
+              hx-target="#template-cards"
+              hx-vals='{"action": "filter"}'
               class="mb-4">
             {% csrf_token %}
             {% crispy template_filters_form %}
+            <div class="d-flex justify-content-end mt-3">
+                <button type="button"
+                        class="btn btn-outline-secondary btn-sm"
+                        onclick="clearTemplateFilters()">
+                    <i class="fas fa-times me-1"></i>Clear All Filters
+                </button>
+            </div>
         </form>
+
+        <script>
+        function clearTemplateFilters() {
+            const form = document.getElementById('template-filter-form');
+
+            // Clear all input fields
+            const inputs = form.querySelectorAll('input[type="text"], input[type="search"]');
+            inputs.forEach(input => {
+                input.value = '';
+            });
+
+            // Reset all select dropdowns to first option
+            const selects = form.querySelectorAll('select');
+            selects.forEach(select => {
+                select.selectedIndex = 0;
+            });
+
+            // Trigger HTMX request to reload data with cleared filters
+            htmx.ajax('POST', form.getAttribute('hx-post'), {
+                target: form.getAttribute('hx-target'),
+                swap: 'innerHTML',
+                values: {
+                    'csrfmiddlewaretoken': form.querySelector('[name="csrfmiddlewaretoken"]').value,
+                    'action': 'filter'
+                }
+            });
+        }
+        </script>
         
         <!-- Template Cards Container -->
         <div id="template-cards">

--- a/templates/pages/building/operational_info/operational_product_list.html
+++ b/templates/pages/building/operational_info/operational_product_list.html
@@ -1,12 +1,53 @@
 {% load crispy_forms_tags %}
 {%  if simulation %}
-<form hx-post="{% url 'building_simulation' building_id=building_id %}" hx-target="#operational-epd-list" hx-vals='{"action": "filter" }'>
+<form id="operational-filter-form"
+      hx-post="{% url 'building_simulation' building_id=building_id %}"
+      hx-target="#operational-epd-list"
+      hx-vals='{"action": "filter" }'>
 {% else %}
-<form hx-post="{% url 'building' building_id=building_id %}" hx-target="#operational-epd-list" hx-vals='{"action": "filter" }'>
+<form id="operational-filter-form"
+      hx-post="{% url 'building' building_id=building_id %}"
+      hx-target="#operational-epd-list"
+      hx-vals='{"action": "filter" }'>
 {% endif %}
     <!-- Create an identifier for this post request -->
     {% crispy epd_filters_form %}
-</form> 
+    <div class="d-flex justify-content-end mt-3">
+        <button type="button"
+                class="btn btn-outline-secondary btn-sm"
+                onclick="clearOperationalFilters()">
+            <i class="fas fa-times me-1"></i>Clear All Filters
+        </button>
+    </div>
+</form>
+
+<script>
+function clearOperationalFilters() {
+    const form = document.getElementById('operational-filter-form');
+
+    // Clear all input fields
+    const inputs = form.querySelectorAll('input[type="text"], input[type="search"]');
+    inputs.forEach(input => {
+        input.value = '';
+    });
+
+    // Reset all select dropdowns to first option
+    const selects = form.querySelectorAll('select');
+    selects.forEach(select => {
+        select.selectedIndex = 0;
+    });
+
+    // Trigger HTMX request to reload data with cleared filters
+    htmx.ajax('POST', form.getAttribute('hx-post'), {
+        target: form.getAttribute('hx-target'),
+        swap: 'innerHTML',
+        values: {
+            'csrfmiddlewaretoken': form.querySelector('[name="csrfmiddlewaretoken"]').value,
+            'action': 'filter'
+        }
+    });
+}
+</script> 
 
 <ul class="list-group mt-3">
     {% for epd in epd_list %}


### PR DESCRIPTION
## Add Clear All Filters Button to Search Modals

Closes #125

### What this does
Implements a "Clear All Filters" button in all search modals, allowing users to reset all filter fields with a single click. This improves user experience by providing a quick way to start a fresh search without manually clearing each filter field.

### Main features
- **Assembly Templates Search Modal**: Added clear filters button that resets template type, dimension, country, category, technique, and search query filters
- **Energy Carrier Emission Factor Search Modal**: Added clear filters button that resets search query, childcategory, country, and type filters
- **EPD Library Search Modal**: Added clear filters button that resets search query, category hierarchy (category/subcategory/childcategory), country, and type filters while preserving dimension parameter
- **HTMX Integration**: Properly triggers HTMX POST requests to reload filtered data immediately after clearing

### Technical implementation
- Added unique form IDs to each search form for JavaScript targeting
- Implemented JavaScript functions that:
  - Clear all text and search input fields
  - Reset all dropdown selects to their first/default option
  - Trigger HTMX ajax requests with only required parameters (CSRF token, action, dimension where needed)
  - Update the UI immediately by swapping target element content
- No backend changes required - leverages existing filter endpoints with empty filter values

### Files modified
- `templates/pages/assembly/templates_list.html` - Assembly templates modal
- `templates/pages/building/operational_info/operational_product_list.html` - Energy carrier modal
- `templates/pages/assembly/epd_list.html` - EPD library modal

### Testing
Test by:
1. Opening each search modal
2. Applying various filters (text search, dropdowns)
3. Clicking "Clear All Filters" button
4. Verifying all fields reset and results reload without filters