### PR TITLE
179-improve-component-list-in-building-view

### DIFF
--- a/pages/views/building/building_simulation.py
+++ b/pages/views/building/building_simulation.py
@@ -15,6 +15,7 @@ from pages.models.building import (
 )
 from pages.views.building.building import handle_building_load
 from pages.views.building.building import handle_assembly_delete
+from pages.views.building.building import get_component_list
 from pages.views.building.operational_products.operational_products import (
     get_op_product,
     get_op_product_list,
@@ -75,6 +76,14 @@ def building_simulation(request, building_id):
 
     # Full reload
     else:
+        # Handle pagination requests
+        if request.GET.get("page"):
+            # Check if it's component pagination or operational product pagination
+            if request.GET.get("component_page"):
+                return get_component_list(request, building_id, simulation=True)
+            else:
+                return get_op_product_list(request, building_id)
+
         context, form, detailedForm, operationalInfoForm = handle_building_load(
             request, building_id, simulation=True
         )

--- a/templates/pages/building/structural_info/assemblies_list.html
+++ b/templates/pages/building/structural_info/assemblies_list.html
@@ -31,9 +31,9 @@
             {% endif%}
 
             <button class="btn btn-danger"
-                    {% if simulation %} hx-delete="{% url 'building_simulation' building_id=building_id %}?component={{ component.assembly_id }}" 
+                    {% if simulation %} hx-delete="{% url 'building_simulation' building_id=building_id %}?component={{ component.assembly_id }}"
                     {% else %} hx-delete="{% url 'building' building_id=building_id %}?component={{ component.assembly_id }}" {% endif %}
-                    hx-target="#item-list" 
+                    hx-target="#item-list"
                     hx-swap="innerHTML"
                     >
                 Delete
@@ -42,6 +42,113 @@
     </li>
     {% endfor %}
 </ul>
+
+<!-- Pagination -->
+<div class="mt-3">
+    <nav aria-label="Pagination">
+        <ul class="pagination justify-content-center">
+            <!-- Jump to First Button -->
+            {% if structural_components.has_previous %}
+            <li class="page-item">
+                <a class="page-link" style="cursor: pointer"
+                   {% if simulation %}
+                   hx-get="{% url 'building_simulation' building_id=building_id %}?page=1&component_page=true&simulation={{ simulation }}"
+                   {% else %}
+                   hx-get="{% url 'building' building_id=building_id %}?page=1&component_page=true&simulation={{ simulation }}"
+                   {% endif %}
+                   hx-target="#item-list"
+                   hx-swap="innerHTML"
+                   aria-label="First">
+                    <span aria-hidden="true">Start</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">Start</span>
+            </li>
+            {% endif %}
+
+            <!-- Previous Button -->
+            {% if structural_components.has_previous %}
+            <li class="page-item">
+                <a class="page-link" style="cursor: pointer"
+                   {% if simulation %}
+                   hx-get="{% url 'building_simulation' building_id=building_id %}?page={{ structural_components.previous_page_number }}&component_page=true&simulation={{ simulation }}"
+                   {% else %}
+                   hx-get="{% url 'building' building_id=building_id %}?page={{ structural_components.previous_page_number }}&component_page=true&simulation={{ simulation }}"
+                   {% endif %}
+                   hx-target="#item-list"
+                   hx-swap="innerHTML"
+                   aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&laquo;</span>
+            </li>
+            {% endif %}
+
+            <!-- Page Numbers -->
+            {% for num in structural_components.paginator.page_range %}
+                {% if num >= structural_components.number|add:-2 and num <= structural_components.number|add:2 %}
+                <li class="page-item {% if num == structural_components.number %}active{% endif %}">
+                    <a class="page-link" style="cursor: pointer"
+                       {% if simulation %}
+                       hx-get="{% url 'building_simulation' building_id=building_id %}?page={{ num }}&component_page=true&simulation={{ simulation }}"
+                       {% else %}
+                       hx-get="{% url 'building' building_id=building_id %}?page={{ num }}&component_page=true&simulation={{ simulation }}"
+                       {% endif %}
+                       hx-target="#item-list"
+                       hx-swap="innerHTML">{{ num }}</a>
+                </li>
+                {% endif %}
+            {% endfor %}
+
+            <!-- Next Button -->
+            {% if structural_components.has_next %}
+            <li class="page-item">
+                <a class="page-link" style="cursor: pointer"
+                   {% if simulation %}
+                   hx-get="{% url 'building_simulation' building_id=building_id %}?page={{ structural_components.next_page_number }}&component_page=true&simulation={{ simulation }}"
+                   {% else %}
+                   hx-get="{% url 'building' building_id=building_id %}?page={{ structural_components.next_page_number }}&component_page=true&simulation={{ simulation }}"
+                   {% endif %}
+                   hx-target="#item-list"
+                   hx-swap="innerHTML"
+                   aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">&raquo;</span>
+            </li>
+            {% endif %}
+
+            <!-- Jump to Last Button -->
+            {% if structural_components.has_next %}
+            <li class="page-item">
+                <a class="page-link" style="cursor: pointer"
+                   {% if simulation %}
+                   hx-get="{% url 'building_simulation' building_id=building_id %}?page={{ structural_components.paginator.num_pages }}&component_page=true&simulation={{ simulation }}"
+                   {% else %}
+                   hx-get="{% url 'building' building_id=building_id %}?page={{ structural_components.paginator.num_pages }}&component_page=true&simulation={{ simulation }}"
+                   {% endif %}
+                   hx-target="#item-list"
+                   hx-swap="innerHTML"
+                   aria-label="Last">
+                    <span aria-hidden="true">End</span>
+                </a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+                <span class="page-link" aria-hidden="true">End</span>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+</div>
 
 <script>
     document.body.addEventListener('componentDeleted', function() {


### PR DESCRIPTION
 ## Add Pagination to Component List in Building View

  Closes #179

  ### What this does

  Implements pagination for the component list in the Building view, allowing users to navigate through large lists of structural components without overwhelming the interface. 

 ### Main features

  - Component List Pagination: Added pagination controls displaying 10 components per page
  - HTMX Integration: Seamless page navigation without full page reloads using HTMX GET requests
  - Consistent UI Pattern: Follows the exact same pagination design used in energy carrier, EPD list, and assembly template modals
  - Simulation Support: Pagination works in both regular building view and simulation mode


 ### Files modified

  - pages/views/building/building.py - Main pagination logic and request routing
  - pages/views/building/building_simulation.py - Simulation mode pagination support
  - templates/pages/building/structural_info/assemblies_list.html - Pagination UI controls

###  Testing

  1. Create a building and add more than 10 structural components/materials
  2. Navigate to the "Building Structural Components" accordion section
  3. Verify pagination controls appear at the bottom of the component list
  4. Click through different pages using Start, Previous, page numbers, Next, and End buttons
  5. Verify only 10 components display per page
  6. Test component deletion and verify the list reloads correctly
  7. Test in simulation mode to ensure pagination works there as well
  8. Verify pagination preserves the simulation flag when navigating between pages
