### PR TITLE
Fix/cooling system number of units error

### DIFF
--- a/pages/forms/cooling_system_form.py
+++ b/pages/forms/cooling_system_form.py
@@ -171,11 +171,16 @@ class CoolingSystemAirConditionerForm(forms.ModelForm):
                 'refrigerant_quantity': 'refrigerant_quantity_kg',
                 'total_cooling_load_for_split_vrv': 'total_cooling_load_rt',
                 'baseline_split_unit_system_efficiency': 'baseline_efficiency_kw_per_rt',
+                'baseline_split_unit_vrv_system_efficiency': 'baseline_efficiency_kw_per_rt',
                 'baseline_leakage_factor': 'baseline_leakage_factor_percent',
                 'total_energy_consumption_of_split_vrv_annually': 'total_energy_consumption_kwh_per_year',
+                'total_chiller_system_annually': 'total_energy_consumption_kwh_per_year',
                 'number_of_split_vrv_units': 'number_of_units',
+                'total_number_of_split_vrv_units': 'number_of_units',
                 'total_split_unit_system_power': 'total_system_power_kw',
+                'total_split_unit_vrv_system': 'total_system_power_kw',
                 'iseer': 'iseer_rating',
+                'isser_rating': 'iseer_rating',
                 'number_of_stars': 'energy_efficiency_label',
             }
 

--- a/pages/tests/test_cooling_system.py
+++ b/pages/tests/test_cooling_system.py
@@ -191,7 +191,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(building.id),
+            'building_uuid': str(building.uuid),
             'cooling_system_type': 'chiller',
             'chiller_system': 'water-cooled',
             'year_of_installation': 2020,
@@ -219,7 +219,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(building.id),
+            'building_uuid': str(building.uuid),
             'cooling_system_type': 'air_conditioner',
             'type_of_air_condition': 'vrv',
             'year_of_installation': 2021,
@@ -245,7 +245,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(chiller_system.building.id),
+            'building_uuid': str(chiller_system.building.uuid),
             'cooling_system_id': chiller_system.id,
             'cooling_system_type': 'chiller',
             'chiller_system': 'air-cooled',
@@ -275,7 +275,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(building.id),
+            'building_uuid': str(building.uuid),
             'year_of_installation': 2020,
         }
         response = client.post(
@@ -293,7 +293,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(building.id),
+            'building_uuid': str(building.uuid),
             'cooling_system_type': 'invalid_type',
         }
         response = client.post(
@@ -310,7 +310,7 @@ class TestCreateOrUpdateCoolingSystemView:
         client.force_login(user)
         url = reverse('cooling_system_create_update')
         data = {
-            'building_id': str(other_building.id),
+            'building_uuid': str(other_building.uuid),
             'cooling_system_type': 'chiller',
             'chiller_system': 'water-cooled',
             'year_of_installation': 2020,
@@ -338,7 +338,7 @@ class TestGetCoolingSystemsView:
     def test_get_cooling_systems_success(self, client, user, building, chiller_system, ac_system):
         """Test successfully retrieving both chiller and AC systems."""
         client.force_login(user)
-        url = reverse('cooling_system_list', kwargs={'building_id': building.id})
+        url = reverse('cooling_system_list', kwargs={'building_uuid': str(building.uuid)})
         response = client.get(url)
         assert response.status_code == 200
         response_data = response.json()
@@ -353,7 +353,7 @@ class TestGetCoolingSystemsView:
     def test_get_cooling_systems_empty_list(self, client, user, building):
         """Test retrieving cooling systems when none exist."""
         client.force_login(user)
-        url = reverse('cooling_system_list', kwargs={'building_id': building.id})
+        url = reverse('cooling_system_list', kwargs={'building_uuid': str(building.uuid)})
         response = client.get(url)
         assert response.status_code == 200
         response_data = response.json()
@@ -363,7 +363,7 @@ class TestGetCoolingSystemsView:
     def test_get_cooling_systems_unauthorized_building(self, client, user, other_building):
         """Test that user cannot retrieve cooling systems from another user's building."""
         client.force_login(user)
-        url = reverse('cooling_system_list', kwargs={'building_id': other_building.id})
+        url = reverse('cooling_system_list', kwargs={'building_uuid': str(other_building.uuid)})
         response = client.get(url)
         assert response.status_code == 404
         response_data = response.json()


### PR DESCRIPTION
## Summary                                                                                                                                                                                              Fixes the "number_of_units field is required" error when saving air conditioner cooling systems by adding missing field name mappings in the `CoolingSystemAirConditionerForm`.

## Problem

  When users attempted to save an air conditioner cooling system, they encountered the following error even when all fields were filled:
 ```json
  {
    "success": false,
    "errors": {
      "number_of_units": ["This field is required."]
    }
  }
```
  The root cause was a mismatch between the field names sent by the frontend and the field names expected by the Django form:


  Changes Made

  1. Fixed Air Conditioner Form Field Mappings (pages/forms/cooling_system_form.py)

  Added missing frontend-to-backend field name mappings in CoolingSystemAirConditionerForm:

  - 'total_number_of_split_vrv_units': 'number_of_units' - Primary fix for the reported error
  - 'baseline_split_unit_vrv_system_efficiency': 'baseline_efficiency_kw_per_rt' - Handles alternative frontend field name
  - 'total_chiller_system_annually': 'total_energy_consumption_kwh_per_year' - Accepts field name used in HTML template
  - 'total_split_unit_vrv_system': 'total_system_power_kw' - Handles alternative frontend field name
  - 'isser_rating': 'iseer_rating' - Handles typo in frontend field name

  2. Updated Test Suite (pages/tests/test_cooling_system.py)

  Fixed tests to use correct field names:
  - Changed all test payloads to use building_uuid instead of building_id (matching the actual API)
  - Updated URL reverse calls for cooling_system_list to use building_uuid parameter
  - All 23 tests now pass successfully

  Testing

  - [x] All 23 cooling system tests pass
  - [x] Verified form accepts all field name variations from the frontend
  - [x] Tested with the exact payload provided by the user
