### PR TITLE
Integration of Operational Data Entry, Structural Components, and Operational Schedule

### DIFF
--- a/libs/step-manager.js
+++ b/libs/step-manager.js
@@ -688,6 +688,26 @@ class StepManager {
         operational_data_saved: true
       };
 
+    } else if (stepKey === 'operational-details/operational-schedule-temperature') {
+      // For operational schedule, we need to call our custom save function
+      // Return a marker that tells saveToServer to use custom logic
+      const form = document.getElementById("form");
+      if (form) {
+        const formData = new FormData(form);
+        let validator = new window.FormValidator(form);
+        let isValid = validator.validate();
+        if (!isValid) {
+          Toast.error("Please correct the errors in the form before proceeding.");
+          throw new Error("Form validation failed.");
+        }
+        return {
+          building_uuid: this.getBuildingId(),
+          _useCustomEndpoint: true,
+          _customEndpoint: 'operational-schedule',
+          ...Object.fromEntries(formData.entries())
+        };
+      }
+      throw new Error("Form not found.");
     } else {
       const form = document.getElementById("form");
       if (form) {
@@ -739,6 +759,35 @@ class StepManager {
       console.log('[StepManager] saveToServer stepData:', stepData);
 
       const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
+
+      // Handle custom endpoints (like operational schedule)
+      if (stepData._useCustomEndpoint && stepData._customEndpoint) {
+        console.log('[StepManager] Using custom endpoint:', stepData._customEndpoint);
+
+        // Remove the markers from the data
+        const cleanData = { ...stepData };
+        delete cleanData._useCustomEndpoint;
+        delete cleanData._customEndpoint;
+
+        const response = await fetch(`/building/step/${stepData._customEndpoint}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrfToken || '',
+          },
+          body: JSON.stringify(cleanData)
+        });
+
+        const result = await response.json();
+        console.log('[StepManager] Custom endpoint response:', result);
+
+        if (!response.ok || !result.success) {
+          console.error('[StepManager] Failed to save via custom endpoint:', result);
+          return { success: false, error: result.error || 'Failed to save' };
+        }
+
+        return { success: true, building_uuid: this.getBuildingId() };
+      }
 
       // Get building_uuid from URL params or from formData
       const urlParams = new URLSearchParams(window.location.search);

--- a/libs/step-manager.js
+++ b/libs/step-manager.js
@@ -660,30 +660,32 @@ class StepManager {
     }
 
     if (stepKey === 'operational-data-entry/operational-data-entry'){
-      const forms = document.getElementById('selected_op_products')?.querySelectorAll("form");
-      if (!forms || forms.length === 0) {
-        Toast.error("No operational products found. Please add at least one.");
+      console.log('[StepManager] Checking operational data entry');
+      const productsList = document.getElementById('selected_op_products');
+      const productItems = productsList?.querySelectorAll("li[id^='epd-']");
+      console.log('[StepManager] Found product items:', productItems ? productItems.length : 0);
+
+      if (!productItems || productItems.length === 0) {
+        console.error('[StepManager] No product items found in #selected_op_products');
+        Toast.error("Please add at least one energy carrier.");
         throw new Error("No operational products found.");
       }
-      /**
-       * @type {{ [k: string]: FormDataEntryValue; }[]}
-       */
-      const combinedData = [];
-      
-      forms.forEach((form) => {
-        const formData = new FormData(form);
-        let validator = new window.FormValidator(form);
-        let isValid = validator.validate();
-        if (!isValid) {
-          Toast.error("Please correct the errors in the form before proceeding.");
-          throw new Error("Form validation failed.");
-        }
-        combinedData.push(Object.fromEntries(formData.entries()));
-      });
-      
-      return { 
+
+      // Check if products are saved to database
+      const form = document.getElementById('operational-products-form');
+      const isSaved = form && form.dataset.saved === 'true';
+
+      if (!isSaved) {
+        console.warn('[StepManager] Operational products have unsaved changes');
+        Toast.warning("Please click 'Save Energy Carriers' before continuing.");
+        throw new Error("Please save energy carriers first.");
+      }
+
+      // Products are already saved, just verify and continue
+      console.log('[StepManager] Operational products already saved, continuing...');
+      return {
         building_uuid: this.getBuildingId(),
-        operation_products: combinedData 
+        operational_data_saved: true
       };
 
     } else {
@@ -733,6 +735,9 @@ class StepManager {
    */
   async saveToServer(stepKey, stepData) {
     try {
+      console.log('[StepManager] saveToServer called with stepKey:', stepKey);
+      console.log('[StepManager] saveToServer stepData:', stepData);
+
       const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value;
 
       // Get building_uuid from URL params or from formData
@@ -746,23 +751,28 @@ class StepManager {
         building_uuid: urlUuid || formUuid || stepData.building_uuid || ''
       };
 
+      const payload = {
+        building_uuid: this.getBuildingId(),
+        step_key: stepKey,
+        data: dataWithUuid
+      };
+
+      console.log('[StepManager] Sending payload to /building/step/save:', payload);
+
       const response = await fetch('/building/step/save', {
         method: this.editMode ? 'PUT' : 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-CSRFToken': csrfToken || '',
         },
-        body: JSON.stringify({
-          building_uuid: this.getBuildingId(),
-          step_key: stepKey,
-          data: dataWithUuid
-        })
+        body: JSON.stringify(payload)
       });
 
       const result = await response.json();
+      console.log('[StepManager] Server response:', result);
 
       if (!response.ok) {
-        console.error('Failed to save step data to server:', result);
+        console.error('[StepManager] Failed to save step data to server:', result);
         return { success: false, error: result.error || 'Failed to save' };
       }
 

--- a/pages/models/assembly.py
+++ b/pages/models/assembly.py
@@ -146,6 +146,13 @@ class Assembly(BaseModel):
         EPD, blank=True, related_name="assemblies", through="StructuralProduct"
     )
     is_boq = models.BooleanField(default=False)
+    is_template = models.BooleanField(default=False, help_text="Whether this assembly can be reused as a template")
+    public = models.BooleanField(default=False, help_text="Whether this template is publicly accessible")
+    draft = models.BooleanField(default=False, help_text="Whether this assembly is in draft state")
+    from_template = models.ForeignKey(
+        'self', on_delete=models.SET_NULL, null=True, blank=True,
+        related_name='derived_assemblies', help_text="Original template this was created from"
+    )
 
     def __str__(self):
         return self.name

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -21,6 +21,8 @@ from .views.building.building import building
 from .views.building.building_simulation import building_simulation
 from .views.building.building_step_operational import \
     building_step_operational_products
+from .views.building.building_step_operational_schedule import \
+    building_step_operational_schedule
 from .views.building.building_step_structural import \
     building_step_structural_products
 from .views.building.components import building_components, new_building
@@ -74,6 +76,7 @@ urlpatterns = [
     path("building/step/save", save_building_step, name="save_building_step"),
     path("building/step/data", get_building_data, name="get_building_data"),
     path("building/step/operational", building_step_operational_products, name="building_step_operational"),
+    path("building/step/operational-schedule", building_step_operational_schedule, name="building_step_operational_schedule"),
     path("building/step/structural", building_step_structural_products, name="building_step_structural"),
     path("building/complete", complete_building_setup, name="complete_building_setup"),
     path("building/<uuid:building_id>/", building, name="building"),

--- a/pages/views/building/add_building_steps.py
+++ b/pages/views/building/add_building_steps.py
@@ -399,7 +399,8 @@ def handle_structural_components_step(request):
                         'name': assembly.name,
                         'comment': assembly.comment or '',
                         'materials': materials,
-                        'total_gwp': total_gwp
+                        'total_gwp': total_gwp,
+                        'is_template': assembly.is_template
                     })
                 else:
                     # Component item
@@ -414,7 +415,8 @@ def handle_structural_components_step(request):
                         'quantity': float(ba.quantity),
                         'comment': assembly.comment or '',
                         'materials': materials,
-                        'total_gwp': total_gwp
+                        'total_gwp': total_gwp,
+                        'is_template': assembly.is_template
                     })
 
         except (ValueError, Building.DoesNotExist):
@@ -568,28 +570,48 @@ def save_building_step(request):
                     OperationalProduct.objects.filter(building=building).delete()
 
                     # Create new operational products
+                    created_count = 0
                     for product in operation_products:
                         # Extract the actual product data (skip csrf token)
-                        epd_uuid = product.get('id')
-                        if epd_uuid:
+                        epd_id = product.get('id')
+                        if epd_id:
                             try:
-                                # The id is a UUID string, need to get the EPD by UUID
-                                # Note: EPD model uses uppercase 'UUID' field
-                                epd_uuid_obj = uuid_lib.UUID(epd_uuid)
-                                epd = EPD.objects.get(UUID=epd_uuid_obj)
+                                # The id is a UUID string (EPD uses UUID as primary key)
+                                epd_uuid_obj = uuid_lib.UUID(epd_id)
+                                epd = EPD.objects.get(id=epd_uuid_obj)
 
-                                OperationalProduct.objects.create(
-                                    building=building,
-                                    epd=epd,
-                                    quantity=float(product.get('quantity', 0)),
-                                    input_unit=product.get('unit', ''),
-                                    description=product.get('description', '')
-                                )
-                            except (ValueError, EPD.DoesNotExist):
-                                logger.warning(f"EPD not found for UUID: {epd_uuid}")
+                                # Extract quantity and unit from the material_* fields
+                                quantity = None
+                                unit = None
+                                description = None
+
+                                # Find the material fields with this EPD's UUID
+                                for key, value in product.items():
+                                    if key.startswith(f'material_{epd_id}_quantity_'):
+                                        quantity = float(value)
+                                    elif key.startswith(f'material_{epd_id}_unit_'):
+                                        unit = value
+                                    elif key.startswith(f'material_{epd_id}_description_'):
+                                        description = value
+
+                                if quantity is not None and unit:
+                                    OperationalProduct.objects.create(
+                                        building=building,
+                                        epd=epd,
+                                        quantity=quantity,
+                                        input_unit=unit,
+                                        description=description or ''
+                                    )
+                                    created_count += 1
+                                else:
+                                    logger.warning(f"Missing quantity or unit for EPD {epd_id}")
+                            except (ValueError, EPD.DoesNotExist) as e:
+                                logger.warning(f"EPD not found for UUID: {epd_id}, error: {e}")
                                 continue
+                        else:
+                            logger.warning(f"Product missing EPD ID: {product}")
 
-                    logger.info(f"Saved {len(operation_products)} operational products for building {building.id}")
+                    logger.info(f"Saved {created_count} operational products for building {building.id}")
 
             except (ValueError, Building.DoesNotExist):
                 return JsonResponse({"error": "Invalid building UUID or building not found"}, status=400)

--- a/pages/views/building/add_building_steps.py
+++ b/pages/views/building/add_building_steps.py
@@ -8,6 +8,7 @@ Each step loads a template and provides necessary context data.
 import json
 import logging
 import uuid as uuid_lib
+from datetime import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
@@ -18,11 +19,10 @@ from cities_light.models import Country
 
 from pages.forms.epds_filter_form import EPDsFilterForm
 from pages.models.base import ALCBTCountryManager
-from pages.models.building import BuildingCategory
+from pages.models.building import Building, BuildingCategory, OperationalProduct
 from pages.models.epd import EPD, EPDType, MaterialCategory
 
 logger = logging.getLogger(__name__)
-from pages.models import Building
 
 
 @login_required
@@ -278,37 +278,48 @@ def handle_operational_data_step(request):
     except MaterialCategory.DoesNotExist:
         logger.warning("Energy carrier categories not found")
     
-    # Load previously saved operational products from session
+    # Load previously saved operational products from database (if building exists)
     selected_products = []
-    building_data = request.session.get("building_form_data", {})
-    operational_data = building_data.get("operational_products", [])
-    
-    for product_data in operational_data:
+    building_uuid = request.GET.get('building_uuid')
+
+    logger.info(f"Loading operational data step with building_uuid: {building_uuid}")
+
+    if building_uuid:
         try:
-            epd = EPD.objects.get(id=product_data["id"])
-            
-            # Get available units and ensure it's a list
-            available_units = epd.get_available_units()
-            if available_units is None:
-                available_units = [epd.declared_unit]
-            elif isinstance(available_units, set):
-                available_units = sorted(list(available_units))
-            elif not isinstance(available_units, list):
-                available_units = list(available_units)
-            
-            selected_products.append({
-                "id": str(epd.id),
-                "name": epd.name,
-                "country": epd.country.name if epd.country else "Unknown",
-                "category": epd.category.name_en if epd.category else "Unknown",
-                "description": product_data.get("description", ""),
-                "selection_unit": product_data.get("unit", epd.declared_unit),
-                "selection_quantity": product_data.get("quantity", ""),
-                "timestamp": product_data.get("timestamp", ""),
-                "op_units": available_units,
-            })
-        except EPD.DoesNotExist:
-            logger.warning(f"EPD {product_data['id']} not found")
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+            logger.info(f"Found building: {building.id} - {building.name}")
+
+            # Get saved operational products from database
+            saved_products = OperationalProduct.objects.filter(
+                building=building
+            ).select_related('epd', 'epd__country', 'epd__category')
+
+            logger.info(f"Found {saved_products.count()} saved operational products")
+
+            for op_product in saved_products:
+                # Get available units and ensure it's a list
+                available_units = op_product.epd.get_available_units()
+                if available_units is None:
+                    available_units = [op_product.epd.declared_unit]
+                elif isinstance(available_units, set):
+                    available_units = sorted(list(available_units))
+                elif not isinstance(available_units, list):
+                    available_units = list(available_units)
+
+                selected_products.append({
+                    "id": str(op_product.epd.id),
+                    "name": op_product.epd.name,
+                    "country": op_product.epd.country.name if op_product.epd.country else "Unknown",
+                    "category": op_product.epd.category.name_en if op_product.epd.category else "Unknown",
+                    "description": op_product.description,
+                    "selection_unit": op_product.input_unit,
+                    "selection_quantity": op_product.quantity,
+                    "timestamp": datetime.now().strftime("%Y%m%d%H%M%S%f"),
+                    "op_units": available_units,
+                })
+        except (ValueError, Building.DoesNotExist):
+            logger.warning(f"Building not found for UUID: {building_uuid}")
     
     context = {
         'epd_filters_form': epd_filters_form,
@@ -325,15 +336,100 @@ def handle_operational_data_step(request):
 # Step 4: Building Structural Components
 def handle_structural_components_step(request):
     """Handle building structural components step."""
+    from pages.models.assembly import Assembly, StructuralProduct
+    from pages.models.building import BuildingAssembly
+
     # Get filter dropdown data for EPD library search
     countries = Country.objects.all().order_by("name")
     epd_categories = MaterialCategory.objects.filter(parent__isnull=True).order_by("name_en")
     epd_types = [{"value": t[0], "label": t[1]} for t in EPDType.choices]
 
+    # Load previously saved assemblies from database (if building exists)
+    boq_items = []
+    component_items = []
+    building_uuid = request.GET.get('building_uuid')
+
+    if building_uuid:
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+
+            # Get saved assemblies with their structural products
+            building_assemblies = BuildingAssembly.objects.filter(
+                building=building
+            ).select_related(
+                'assembly'
+            ).prefetch_related(
+                'assembly__structuralproduct_set__epd',
+                'assembly__structuralproduct_set__epd__country',
+                'assembly__structuralproduct_set__epd__category',
+                'assembly__structuralproduct_set__classification__category'
+            )
+
+            for ba in building_assemblies:
+                assembly = ba.assembly
+
+                # Get materials for this assembly
+                materials = []
+                for sp in assembly.structuralproduct_set.all():
+                    material = {
+                        'epd_id': sp.epd.id,
+                        'name': sp.epd.name,
+                        'quantity': float(sp.quantity),
+                        'unit': sp.input_unit,
+                        'description': sp.description or '',
+                        'gwp': float(sp.epd.get_gwp_impact_sum("A1-A3") or 0),
+                        'country': sp.epd.country.name if sp.epd.country else 'Unknown',
+                    }
+
+                    # Add category for BOQ items
+                    if assembly.is_boq and sp.classification:
+                        material['category'] = sp.classification.category.id
+                        material['category_name'] = sp.classification.category.name
+
+                    materials.append(material)
+
+                # Calculate total GWP
+                total_gwp = sum(m['gwp'] * m['quantity'] for m in materials)
+
+                if assembly.is_boq:
+                    # BOQ item
+                    boq_items.append({
+                        'id': assembly.id,
+                        'name': assembly.name,
+                        'comment': assembly.comment or '',
+                        'materials': materials,
+                        'total_gwp': total_gwp
+                    })
+                else:
+                    # Component item
+                    classification = assembly.classification
+                    component_items.append({
+                        'id': assembly.id,
+                        'title': assembly.name,
+                        'category': classification.category.id if classification else None,
+                        'category_name': classification.category.name if classification else '',
+                        'technique': classification.technique.id if classification and classification.technique else None,
+                        'dimension': assembly.dimension,
+                        'quantity': float(ba.quantity),
+                        'comment': assembly.comment or '',
+                        'materials': materials,
+                        'total_gwp': total_gwp
+                    })
+
+        except (ValueError, Building.DoesNotExist):
+            logger.warning(f"Building not found for UUID: {building_uuid}")
+        except Exception as e:
+            logger.exception(f"Error loading structural assemblies: {str(e)}")
+
+    logger.info(f"Loaded {len(boq_items)} BOQ items and {len(component_items)} component items")
+
     context = {
         'countries': countries,
         'epd_categories': epd_categories,
         'epd_types': epd_types,
+        'boq_items': boq_items,
+        'component_items': component_items,
     }
     return render(
         request,
@@ -449,6 +545,57 @@ def save_building_step(request):
                     return JsonResponse({"error": "Invalid building UUID"}, status=400)
             else:
                 return JsonResponse({"error": "Building must be created in step 1.1 first"}, status=400)
+
+        # Step 3: Operational Data Entry - Save operational products
+        elif step_key in ["operational-data-entry/operational-data-entry", "operational-data-entry/operational-data-entry.html"]:
+            logger.info(f"Handling operational data entry step for building_uuid: {building_uuid}")
+            logger.info(f"Step data: {step_data}")
+
+            if not building_uuid:
+                return JsonResponse({"error": "Building UUID is required"}, status=400)
+
+            try:
+                uuid_obj = uuid_lib.UUID(building_uuid)
+                building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+                logger.info(f"Found building: {building.id}")
+
+                # Extract operational products from step_data
+                operation_products = step_data.get('operation_products', [])
+                logger.info(f"Found {len(operation_products)} operational products in step_data")
+
+                if operation_products:
+                    # Delete existing operational products for this building
+                    OperationalProduct.objects.filter(building=building).delete()
+
+                    # Create new operational products
+                    for product in operation_products:
+                        # Extract the actual product data (skip csrf token)
+                        epd_uuid = product.get('id')
+                        if epd_uuid:
+                            try:
+                                # The id is a UUID string, need to get the EPD by UUID
+                                # Note: EPD model uses uppercase 'UUID' field
+                                epd_uuid_obj = uuid_lib.UUID(epd_uuid)
+                                epd = EPD.objects.get(UUID=epd_uuid_obj)
+
+                                OperationalProduct.objects.create(
+                                    building=building,
+                                    epd=epd,
+                                    quantity=float(product.get('quantity', 0)),
+                                    input_unit=product.get('unit', ''),
+                                    description=product.get('description', '')
+                                )
+                            except (ValueError, EPD.DoesNotExist):
+                                logger.warning(f"EPD not found for UUID: {epd_uuid}")
+                                continue
+
+                    logger.info(f"Saved {len(operation_products)} operational products for building {building.id}")
+
+            except (ValueError, Building.DoesNotExist):
+                return JsonResponse({"error": "Invalid building UUID or building not found"}, status=400)
+            except Exception as e:
+                logger.exception(f"Error saving operational products: {str(e)}")
+                return JsonResponse({"error": str(e)}, status=500)
 
         # For all other steps, just acknowledge receipt
         # Operational systems are saved immediately via their dedicated APIs

--- a/pages/views/building/building_step_operational.py
+++ b/pages/views/building/building_step_operational.py
@@ -5,6 +5,7 @@ This provides HTMX endpoints for filtering, selecting, and saving operational pr
 
 import logging
 from datetime import datetime
+import uuid as uuid_lib
 
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
@@ -14,8 +15,10 @@ from django.views.decorators.http import require_http_methods
 
 from pages.forms.epds_filter_form import EPDsFilterForm
 from pages.models.base import ALCBTCountryManager
+from pages.models.building import Building, OperationalProduct
 from pages.models.epd import EPD, MaterialCategory
 from pages.views.assembly.epd_processing import get_epd_list
+from pages.views.building.operational_products.operational_products import handle_op_products_save
 
 logger = logging.getLogger(__name__)
 
@@ -135,77 +138,69 @@ def handle_select_product(request):
 
 def handle_save_products(request):
     """
-    Save selected operational products to session.
-    In the wizard context, we store in session until building is finalized.
+    Save selected operational products directly to database.
+    Uses the existing handle_op_products_save() function.
     """
-    # Extract selected EPDs from form data
-    selected_epds = {}
-    
-    for key, value in request.POST.items():
-        if key.startswith("material_") and "_quantity" in key:
-            key_array = key.split("_")
-            epd_id = key_array[1]
-            timestamp = key_array[-1]
-            
-            # Build the product data
-            selected_epds[epd_id + timestamp] = {
-                "id": epd_id,
-                "quantity": float(value) if value else 0,
-                "unit": request.POST.get(f"material_{epd_id}_unit_{timestamp}", ""),
-                "description": request.POST.get(f"material_{epd_id}_description_{timestamp}", ""),
-                "timestamp": timestamp
-            }
-    
-    # Store in session
-    if "building_form_data" not in request.session:
-        request.session["building_form_data"] = {}
-    
-    request.session["building_form_data"]["operational_products"] = list(selected_epds.values())
-    request.session.modified = True
-    
-    logger.info(f"Saved {len(selected_epds)} operational products to session")
-    
-    # Return the form with saved data (just the form portion for HTMX swap)
+    # Get building UUID from POST data
+    building_uuid = request.POST.get("building_uuid")
+
+    if not building_uuid:
+        return JsonResponse({"error": "Building UUID is required"}, status=400)
+
+    try:
+        # Get the building instance
+        uuid_obj = uuid_lib.UUID(building_uuid)
+        building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+    except (ValueError, Building.DoesNotExist):
+        logger.error(f"Invalid building UUID or building not found: {building_uuid}")
+        return JsonResponse({"error": "Invalid building UUID or building not found"}, status=400)
+
+    # Use the existing save handler to save directly to database
+    # This function deletes existing operational products and creates new ones
+    handle_op_products_save(request, building.id, simulation=False)
+
+    logger.info(f"Saved operational products to database for building {building.id}")
+
+    # Retrieve the saved products from database to display
+    saved_products = OperationalProduct.objects.filter(
+        building=building
+    ).select_related('epd', 'epd__country', 'epd__category')
+
     selected_products = []
-    for product_data in selected_epds.values():
-        try:
-            epd = EPD.objects.get(id=product_data["id"])
-            
-            # Get available units and ensure it's a list
-            available_units = epd.get_available_units()
-            if available_units is None:
-                available_units = [epd.declared_unit]
-            elif isinstance(available_units, set):
-                available_units = sorted(list(available_units))
-            elif not isinstance(available_units, list):
-                available_units = list(available_units)
-            
-            selected_products.append({
-                "id": str(epd.id),
-                "name": epd.name,
-                "country": epd.country.name if epd.country else "Unknown",
-                "category": epd.category.name_en if epd.category else "Unknown",
-                "description": product_data["description"],
-                "selection_unit": product_data["unit"],
-                "selection_quantity": product_data["quantity"],
-                "timestamp": product_data["timestamp"],
-                "op_units": available_units,
-            })
-        except EPD.DoesNotExist:
-            logger.warning(f"EPD {product_data['id']} not found")
-    
+    for op_product in saved_products:
+        # Get available units and ensure it's a list
+        available_units = op_product.epd.get_available_units()
+        if available_units is None:
+            available_units = [op_product.epd.declared_unit]
+        elif isinstance(available_units, set):
+            available_units = sorted(list(available_units))
+        elif not isinstance(available_units, list):
+            available_units = list(available_units)
+
+        selected_products.append({
+            "id": str(op_product.epd.id),
+            "name": op_product.epd.name,
+            "country": op_product.epd.country.name if op_product.epd.country else "Unknown",
+            "category": op_product.epd.category.name_en if op_product.epd.category else "Unknown",
+            "description": op_product.description,
+            "selection_unit": op_product.input_unit,
+            "selection_quantity": op_product.quantity,
+            "timestamp": datetime.now().strftime("%Y%m%d%H%M%S%f"),
+            "op_units": available_units,
+        })
+
     context = {
         "selected_products": selected_products,
     }
-    
+
     # Return just the form for HTMX swap
     response = render(
         request,
         "pages/add-building/components/operational-data-entry/_form_section.html",
         context
     )
-    
+
     # Add success header for HTMX
     response['HX-Trigger'] = 'operationalProductsSaved'
-    
+
     return response

--- a/pages/views/building/building_step_operational.py
+++ b/pages/views/building/building_step_operational.py
@@ -24,20 +24,36 @@ logger = logging.getLogger(__name__)
 
 
 @login_required
-@require_http_methods(["GET", "POST", "PUT"])
+@require_http_methods(["GET", "POST", "PUT", "DELETE"])
 def building_step_operational_products(request):
     """
     Handle operational products selection for the add-building wizard.
     Supports GET for listing/filtering EPDs and POST for adding/saving products.
     """
-    action = request.POST.get("action") if request.method == "POST" else "list"
-    
+    import json
+
+    action = "list"
+
+    if request.method == "POST":
+        # Try to get action from JSON body first
+        if request.content_type == 'application/json':
+            try:
+                data = json.loads(request.body)
+                action = data.get("action", "list")
+            except json.JSONDecodeError:
+                action = request.POST.get("action", "list")
+        else:
+            # Fall back to form data
+            action = request.POST.get("action", "list")
+
     if action == "filter":
         return handle_filter_epds(request)
     elif action == "select_op_product":
         return handle_select_product(request)
     elif action == "save_op_products":
         return handle_save_products(request)
+    elif action == "delete_op_product":
+        return handle_delete_product(request)
     else:
         # Default: return EPD list
         return handle_filter_epds(request)
@@ -204,3 +220,49 @@ def handle_save_products(request):
     response['HX-Trigger'] = 'operationalProductsSaved'
 
     return response
+
+
+def handle_delete_product(request):
+    """
+    Delete a specific operational product from the building.
+    """
+    import json
+
+    try:
+        data = json.loads(request.body)
+        building_uuid = data.get("building_uuid")
+        epd_id = data.get("epd_id")
+
+        if not building_uuid or not epd_id:
+            return JsonResponse({"success": False, "error": "Missing required fields"}, status=400)
+
+        # Get the building instance
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+        except (ValueError, Building.DoesNotExist):
+            return JsonResponse({"success": False, "error": "Building not found"}, status=404)
+
+        # Delete the operational product
+        deleted_count, _ = OperationalProduct.objects.filter(
+            building=building,
+            epd_id=epd_id
+        ).delete()
+
+        if deleted_count > 0:
+            logger.info(f"Deleted operational product {epd_id} from building {building.id}")
+            return JsonResponse({
+                "success": True,
+                "message": "Energy carrier removed successfully"
+            })
+        else:
+            return JsonResponse({
+                "success": False,
+                "error": "Energy carrier not found"
+            }, status=404)
+
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON data"}, status=400)
+    except Exception as e:
+        logger.exception(f"Error deleting operational product: {str(e)}")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)

--- a/pages/views/building/building_step_operational_schedule.py
+++ b/pages/views/building/building_step_operational_schedule.py
@@ -1,0 +1,125 @@
+"""
+View for handling operational schedule and temperature data in the add-building wizard.
+"""
+
+import json
+import logging
+import uuid as uuid_lib
+
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from pages.models.building import Building
+
+logger = logging.getLogger(__name__)
+
+
+@login_required
+@require_http_methods(["GET", "POST"])
+def building_step_operational_schedule(request):
+    """
+    Handle operational schedule and temperature data for the add-building wizard.
+
+    GET: Returns form with existing data (if any)
+    POST: Saves operational schedule and temperature data
+    """
+
+    if request.method == "GET":
+        return handle_get_schedule(request)
+    else:
+        return handle_save_schedule(request)
+
+
+def handle_get_schedule(request):
+    """
+    Get existing operational schedule data for a building.
+    Returns JSON with the data to populate the form.
+    """
+    building_uuid = request.GET.get("building_uuid")
+
+    if not building_uuid:
+        return JsonResponse({"error": "Building UUID is required"}, status=400)
+
+    try:
+        uuid_obj = uuid_lib.UUID(building_uuid)
+        building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+    except (ValueError, Building.DoesNotExist):
+        return JsonResponse({"error": "Building not found"}, status=404)
+
+    # Return existing data
+    data = {
+        "success": True,
+        "data": {
+            "number_of_residents": building.num_residents,
+            "annual_operating_hours_per_day": building.hours_per_workday,
+            "annual_operating_days_per_week": building.workdays_per_week,
+            "annual_operating_weeks_per_year": building.weeks_per_year,
+            "room_heating_temperature": float(building.heating_temp) if building.heating_temp else None,
+            "heating_temperature_unit": building.heating_temp_unit,
+            "room_cooling_temperature": float(building.cooling_temp) if building.cooling_temp else None,
+            "cooling_temperature_unit": building.cooling_temp_unit,
+        }
+    }
+
+    return JsonResponse(data)
+
+
+def handle_save_schedule(request):
+    """
+    Save operational schedule and temperature data to the building.
+
+    Expected POST data (JSON):
+    {
+        "building_uuid": str,
+        "number_of_residents": int,
+        "annual_operating_hours_per_day": int,
+        "annual_operating_days_per_week": int,
+        "annual_operating_weeks_per_year": int,
+        "room_heating_temperature": float,
+        "heating_temperature_unit": str ("celsius" or "fahrenheit"),
+        "room_cooling_temperature": float,
+        "cooling_temperature_unit": str ("celsius" or "fahrenheit")
+    }
+    """
+    try:
+        data = json.loads(request.body)
+        building_uuid = data.get("building_uuid")
+
+        if not building_uuid:
+            return JsonResponse({"success": False, "error": "Building UUID is required"}, status=400)
+
+        # Get building
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+        except (ValueError, Building.DoesNotExist):
+            return JsonResponse({"success": False, "error": "Building not found"}, status=404)
+
+        # Update operational schedule fields
+        building.num_residents = data.get("number_of_residents")
+        building.hours_per_workday = data.get("annual_operating_hours_per_day")
+        building.workdays_per_week = data.get("annual_operating_days_per_week")
+        building.weeks_per_year = data.get("annual_operating_weeks_per_year")
+
+        # Update temperature fields
+        building.heating_temp = data.get("room_heating_temperature")
+        building.heating_temp_unit = data.get("heating_temperature_unit")
+        building.cooling_temp = data.get("room_cooling_temperature")
+        building.cooling_temp_unit = data.get("cooling_temperature_unit")
+
+        building.save()
+
+        logger.info(f"Saved operational schedule for building {building.id}")
+
+        return JsonResponse({
+            "success": True,
+            "message": "Operational schedule and temperature saved successfully"
+        })
+
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON data"}, status=400)
+    except Exception as e:
+        logger.exception(f"Error saving operational schedule: {str(e)}")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)

--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -3,17 +3,24 @@ View for handling structural components selection in the add-building wizard.
 Provides HTMX endpoints for filtering, selecting, and managing structural EPDs.
 """
 
+import json
 import logging
 from datetime import datetime
+import uuid as uuid_lib
 
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
 from pages.forms.epds_filter_form import EPDsFilterForm
-from pages.models.assembly import AssemblyCategory, AssemblyTechnique, AssemblyCategoryTechnique
+from pages.models.assembly import (
+    Assembly, AssemblyCategory, AssemblyDimension, AssemblyMode,
+    AssemblyTechnique, AssemblyCategoryTechnique, StructuralProduct
+)
 from pages.models.base import ALCBTCountryManager
+from pages.models.building import Building, BuildingAssembly
 from pages.models.epd import EPD, MaterialCategory
 from pages.views.assembly.epd_filtering import get_filtered_epd_list
 from pages.views.assembly.epd_processing import get_epd_list
@@ -40,6 +47,10 @@ def building_step_structural_products(request):
         return handle_get_categories(request)
     elif action == "get_subcategories":
         return handle_get_subcategories(request)
+    elif action == "save_assembly":
+        return handle_save_assembly(request)
+    elif action == "delete_assembly":
+        return handle_delete_assembly(request)
     else:
         return handle_filter_epds(request)
 
@@ -188,3 +199,245 @@ def handle_get_subcategories(request):
     except Exception as e:
         logger.error(f"Error fetching subcategories: {e}")
         return HttpResponse('<option value="">Error loading subcategories</option>')
+
+
+@transaction.atomic
+def handle_save_assembly(request):
+    """
+    Save a structural assembly (BOQ or component) to database.
+
+    Expected POST data (JSON):
+    {
+        "building_uuid": str,
+        "mode": "boq" or "component",
+        "assembly_id": int (optional, for updates),
+        "assembly_data": {
+            # For BOQ:
+            "name": str,
+            "comment": str,
+            "materials": [
+                {
+                    "epd_id": int,
+                    "quantity": float,
+                    "unit": str,
+                    "description": str,
+                    "category": int,  # AssemblyCategory ID
+                    "gwp": float
+                }
+            ]
+
+            # For Component:
+            "title": str,
+            "category": int,  # AssemblyCategory ID
+            "technique": int,  # AssemblyTechnique ID (optional)
+            "dimension": str,  # area, length, mass, volume
+            "quantity": float,
+            "comment": str,
+            "materials": [
+                {
+                    "epd_id": int,
+                    "quantity": float,
+                    "unit": str,
+                    "description": str,
+                    "gwp": float
+                }
+            ]
+        }
+    }
+    """
+    try:
+        data = json.loads(request.body)
+        building_uuid = data.get("building_uuid")
+        mode = data.get("mode")  # "boq" or "component"
+        assembly_data = data.get("assembly_data", {})
+        assembly_id = data.get("assembly_id")  # For updates
+
+        if not building_uuid:
+            return JsonResponse({"success": False, "error": "Building UUID is required"}, status=400)
+
+        if not mode or mode not in ["boq", "component"]:
+            return JsonResponse({"success": False, "error": "Invalid mode"}, status=400)
+
+        # Get building
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+        except (ValueError, Building.DoesNotExist):
+            logger.error(f"Building not found for UUID: {building_uuid}")
+            return JsonResponse({"success": False, "error": "Building not found"}, status=404)
+
+        # Validate materials
+        materials = assembly_data.get("materials", [])
+        if not materials:
+            return JsonResponse({"success": False, "error": "At least one material is required"}, status=400)
+
+        # Create or update Assembly
+        if assembly_id:
+            # Update existing assembly
+            try:
+                assembly = Assembly.objects.get(id=assembly_id, created_by=request.user)
+                # Delete existing structural products
+                StructuralProduct.objects.filter(assembly=assembly).delete()
+            except Assembly.DoesNotExist:
+                return JsonResponse({"success": False, "error": "Assembly not found"}, status=404)
+        else:
+            # Create new assembly
+            assembly = Assembly(created_by=request.user)
+
+        # Set assembly fields based on mode
+        if mode == "boq":
+            assembly.name = assembly_data.get("name", "Untitled BOQ")
+            assembly.comment = assembly_data.get("comment", "")
+            assembly.is_boq = True
+            assembly.mode = AssemblyMode.CUSTOM
+            assembly.dimension = AssemblyDimension.AREA  # Default for BOQ
+        else:  # component
+            assembly.name = assembly_data.get("title", "Untitled Component")
+            assembly.comment = assembly_data.get("comment", "")
+            assembly.is_boq = False
+            assembly.mode = AssemblyMode.CUSTOM
+            assembly.dimension = assembly_data.get("dimension", AssemblyDimension.AREA)
+
+        assembly.save()
+
+        # Create StructuralProduct records for each material
+        for material in materials:
+            epd_id = material.get("epd_id")
+            if not epd_id:
+                continue
+
+            try:
+                epd = EPD.objects.get(id=epd_id)
+            except EPD.DoesNotExist:
+                logger.warning(f"EPD {epd_id} not found, skipping")
+                continue
+
+            # Get classification (category + technique)
+            classification = None
+            if mode == "boq":
+                # BOQ mode: each material can have its own category
+                category_id = material.get("category")
+                if category_id:
+                    try:
+                        classification = AssemblyCategoryTechnique.objects.get(
+                            category_id=category_id,
+                            technique__isnull=True  # BOQ doesn't use techniques
+                        )
+                    except AssemblyCategoryTechnique.DoesNotExist:
+                        logger.warning(f"Classification not found for category {category_id}")
+            else:
+                # Component mode: all materials share the same category + technique
+                category_id = assembly_data.get("category")
+                technique_id = assembly_data.get("technique") or None
+
+                if category_id:
+                    try:
+                        classification = AssemblyCategoryTechnique.objects.get(
+                            category_id=category_id,
+                            technique_id=technique_id
+                        )
+                    except AssemblyCategoryTechnique.DoesNotExist:
+                        logger.warning(f"Classification not found for category {category_id}, technique {technique_id}")
+
+            StructuralProduct.objects.create(
+                epd=epd,
+                assembly=assembly,
+                quantity=material.get("quantity", 0),
+                input_unit=material.get("unit", epd.declared_unit),
+                description=material.get("description", ""),
+                classification=classification
+            )
+
+        # Create or update BuildingAssembly join record
+        if mode == "component":
+            # Component mode has quantity at assembly level
+            assembly_quantity = assembly_data.get("quantity", 1)
+        else:
+            # BOQ mode doesn't have assembly-level quantity
+            assembly_quantity = 1
+
+        building_assembly, created = BuildingAssembly.objects.update_or_create(
+            building=building,
+            assembly=assembly,
+            defaults={
+                "quantity": assembly_quantity,
+                "reporting_life_cycle": 50  # Default lifecycle
+            }
+        )
+
+        logger.info(f"Saved assembly {assembly.id} ({mode}) for building {building.id}")
+
+        # Return success with assembly data
+        return JsonResponse({
+            "success": True,
+            "message": f"{'BOQ' if mode == 'boq' else 'Component'} saved successfully",
+            "assembly": {
+                "id": assembly.id,
+                "name": assembly.name,
+                "mode": mode,
+                "materials_count": materials.__len__()
+            }
+        })
+
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON data"}, status=400)
+    except Exception as e:
+        logger.exception(f"Error saving assembly: {str(e)}")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+
+@transaction.atomic
+def handle_delete_assembly(request):
+    """
+    Delete a structural assembly.
+
+    Expected POST data (JSON):
+    {
+        "building_uuid": str,
+        "assembly_id": int
+    }
+    """
+    try:
+        data = json.loads(request.body)
+        building_uuid = data.get("building_uuid")
+        assembly_id = data.get("assembly_id")
+
+        if not building_uuid or not assembly_id:
+            return JsonResponse({"success": False, "error": "Missing required fields"}, status=400)
+
+        # Get building
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid)
+            building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+        except (ValueError, Building.DoesNotExist):
+            return JsonResponse({"success": False, "error": "Building not found"}, status=404)
+
+        # Delete BuildingAssembly (cascades to delete assembly if not used elsewhere)
+        try:
+            building_assembly = BuildingAssembly.objects.get(
+                building=building,
+                assembly_id=assembly_id
+            )
+            assembly_name = building_assembly.assembly.name
+            building_assembly.delete()
+
+            # Also delete the assembly itself if it's custom and only belonged to this building
+            assembly = Assembly.objects.filter(id=assembly_id, created_by=request.user)
+            if assembly.exists() and not BuildingAssembly.objects.filter(assembly_id=assembly_id).exists():
+                assembly.delete()
+
+            logger.info(f"Deleted assembly {assembly_id} from building {building.id}")
+
+            return JsonResponse({
+                "success": True,
+                "message": f"Assembly '{assembly_name}' deleted successfully"
+            })
+
+        except BuildingAssembly.DoesNotExist:
+            return JsonResponse({"success": False, "error": "Assembly not found"}, status=404)
+
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON data"}, status=400)
+    except Exception as e:
+        logger.exception(f"Error deleting assembly: {str(e)}")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)

--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -32,8 +32,20 @@ logger = logging.getLogger(__name__)
 @require_http_methods(["GET", "POST"])
 def building_step_structural_products(request):
     """Handle structural products selection for the add-building wizard."""
+    # Check if request has JSON body
+    action = None
     if request.method == "POST":
-        action = request.POST.get("action", "list")
+        # Try to parse JSON body first
+        if request.content_type == 'application/json':
+            try:
+                data = json.loads(request.body)
+                action = data.get("action")
+            except json.JSONDecodeError:
+                pass
+
+        # Fall back to form data
+        if not action:
+            action = request.POST.get("action", "list")
     else:
         action = request.GET.get("action", "list")
 
@@ -58,13 +70,14 @@ def building_step_structural_products(request):
 def handle_filter_epds(request):
     """Filter and return structural EPD list."""
     dimension = request.POST.get("dimension") or request.GET.get("dimension")
+    mode = request.POST.get("mode") or request.GET.get("mode") or "boq"
     epd_list, _ = get_epd_list(request, dimension=dimension, operational=False)
 
     form = EPDsFilterForm(request.POST if request.method == "POST" else request.GET)
 
     req = request.POST if request.method == "POST" else request.GET
     filter_params = []
-    for key in ['search_query', 'country', 'category', 'subcategory', 'childcategory', 'type', 'dimension']:
+    for key in ['search_query', 'country', 'category', 'subcategory', 'childcategory', 'type', 'dimension', 'mode']:
         value = req.get(key)
         if value:
             filter_params.append(f"{key}={value}")
@@ -75,6 +88,7 @@ def handle_filter_epds(request):
         "filters": filters_str,
         "epd_filters_form": form,
         "dimension": dimension,
+        "mode": mode,
     }
 
     return render(
@@ -285,19 +299,25 @@ def handle_save_assembly(request):
             assembly = Assembly(created_by=request.user)
 
         # Set assembly fields based on mode
+        is_template = assembly_data.get("is_template", False)
+        logger.info(f"is_template value from assembly_data: {is_template}, type: {type(is_template)}")
+
         if mode == "boq":
             assembly.name = assembly_data.get("name", "Untitled BOQ")
             assembly.comment = assembly_data.get("comment", "")
             assembly.is_boq = True
             assembly.mode = AssemblyMode.CUSTOM
             assembly.dimension = AssemblyDimension.AREA  # Default for BOQ
+            assembly.is_template = is_template
         else:  # component
             assembly.name = assembly_data.get("title", "Untitled Component")
             assembly.comment = assembly_data.get("comment", "")
             assembly.is_boq = False
             assembly.mode = AssemblyMode.CUSTOM
             assembly.dimension = assembly_data.get("dimension", AssemblyDimension.AREA)
+            assembly.is_template = is_template
 
+        logger.info(f"About to save assembly with is_template={assembly.is_template}")
         assembly.save()
 
         # Create StructuralProduct records for each material

--- a/templates/pages/add-building/components/building-information/building-details.html
+++ b/templates/pages/add-building/components/building-information/building-details.html
@@ -122,38 +122,9 @@
   </fieldset>
 
   <fieldset class="fieldset">
-    <legend class="fieldset-legend">Room cooling temperature</legend>
-    <label class="input w-full">
-      <input name="room_cooling_temperature" type="number" placeholder="e.g. 10" required />
-    </label>
-  </fieldset>
-
-  <fieldset class="fieldset">
     <legend class="fieldset-legend">Number of floors below ground</legend>
     <label class="input w-full">
       <input name="floors_below_ground" type="number" placeholder="e.g. 3" required min="0" {% if building_data.floors_below_ground %}value="{{ building_data.floors_below_ground }}"{% endif %} />
-    </label>
-  </fieldset>
-
-  <fieldset class="fieldset">
-    <legend class="fieldset-legend">
-      Energy consumption of building
-      <span class="text-[var(--text--sub-600)]">(%)</span>
-    </legend>
-    <label class="input w-full">
-      <input name="energy_consumption" type="number" placeholder="e.g. 10" required min="1" />
-      <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">%</span>
-    </label>
-  </fieldset>
-
-  <fieldset class="fieldset">
-    <legend class="fieldset-legend">Energy monitoring & control systems</legend>
-    <label class="w-full">
-      <select name="energy_monitoring_control_systems" class="select w-full" required>
-        <option disabled selected value="">e.g. Yes</option>
-        <option>Yes</option>
-        <option>No</option>
-      </select>
     </label>
   </fieldset>
 

--- a/templates/pages/add-building/components/building-structural-components/_epd_list.html
+++ b/templates/pages/add-building/components/building-structural-components/_epd_list.html
@@ -32,7 +32,7 @@
         class="btn btn-sm btn-outline border-[var(--stroke--soft-200)] rounded-[var(--radius-8)]"
         hx-post="{% url 'building_step_structural' %}"
         hx-vals='{"action": "select_structural_product", "epd_id": "{{ epd.id }}", "mode": "{{ mode|default:'boq' }}", "dimension": "{{ dimension|default:'area' }}"}'
-        hx-target="#structural_materials_list"
+        hx-target="{% if mode == 'component' %}#component_materials_list{% else %}#structural_materials_list{% endif %}"
         hx-swap="beforeend"
       >
         <span data-icon="add-large-fill" data-size="20" data-color="var(--icon--strong-950)"></span>

--- a/templates/pages/add-building/components/building-structural-components/_selected_material.html
+++ b/templates/pages/add-building/components/building-structural-components/_selected_material.html
@@ -41,11 +41,8 @@
             min="0"
             class="material-quantity"
             required />
-      <select class="select select-ghost w-fit !outline-none !border-none material-unit">
-        {% for unit in epd.available_units %}
-        <option value="{{ unit }}" {% if unit == epd.selection_unit %}selected{% endif %}>{{ unit }}</option>
-        {% endfor %}
-      </select>
+      <span class="text-xs text-[var(--text--sub-600)] material-unit" data-unit="{{ epd.selection_unit }}">{{ epd.selection_unit }}</span>
+      <input type="hidden" class="material-unit-value" value="{{ epd.selection_unit }}" />
     </label>
 
     <div class="w-[0.0625rem] bg-[var(--stroke--soft-200)] h-full my-2"></div>

--- a/templates/pages/add-building/components/building-structural-components/_selected_material.html
+++ b/templates/pages/add-building/components/building-structural-components/_selected_material.html
@@ -1,10 +1,9 @@
-<form>
-    <li class="bg-[var(--bg--weak-50)] rounded-xl p-4"
-        id="material-{{ epd.id }}-{{ epd.timestamp }}"
-        data-epd-id="{{ epd.id }}"
-        data-timestamp="{{ epd.timestamp }}"
-        data-name="{{ epd.name }}"
-        data-gwp="{{ epd.gwp }}">
+<li class="bg-[var(--bg--weak-50)] rounded-xl p-4"
+    id="material-{{ epd.id }}-{{ epd.timestamp }}"
+    data-epd-id="{{ epd.id }}"
+    data-timestamp="{{ epd.timestamp }}"
+    data-name="{{ epd.name }}"
+    data-gwp="{{ epd.gwp }}">
       <div class="flex items-center justify-between mb-2 w-full">
         <span class="text-sm/5 font-medium truncate flex-1">{{ epd.name|truncatechars:50 }}</span>
         <div class="flex items-center gap-2">
@@ -66,4 +65,3 @@
       <input type="hidden" name="material_{{ epd.id }}_id_{{ epd.timestamp }}" value="{{ epd.id }}" />
       <input type="hidden" name="material_{{ epd.id }}_gwp_{{ epd.timestamp }}" value="{{ epd.gwp }}" />
     </li>
-</form>

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -320,6 +320,12 @@
   </div>
 </dialog>
 
+<!-- Saved data from backend -->
+{% if boq_items or component_items %}
+{{ boq_items|json_script:"boq-items-data" }}
+{{ component_items|json_script:"component-items-data" }}
+{% endif %}
+
 <script>
 class StructuralComponentManager {
   constructor() {
@@ -615,7 +621,7 @@ class StructuralComponentManager {
     this.updateMaterialsUI();
   }
 
-  saveBoq() {
+  async saveBoq() {
     const name = document.getElementById('boq_name').value.trim();
     if (!name) {
       Toast.error('Please enter a BOQ name');
@@ -638,26 +644,78 @@ class StructuralComponentManager {
 
     const totalGwp = materials.reduce((sum, m) => sum + (m.gwp * m.quantity), 0);
 
-    const item = {
+    const assemblyData = {
       name: name,
       comment: document.getElementById('boq_comment').value,
-      materials: materials,
-      total_gwp: totalGwp
+      materials: materials
     };
 
-    if (this.editingIndex !== null) {
-      this.boqItems[this.editingIndex] = item;
-    } else {
-      this.boqItems.push(item);
+    // Get building UUID from URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const buildingUuid = urlParams.get('building_uuid');
+
+    if (!buildingUuid) {
+      Toast.error('Building UUID not found');
+      return;
     }
 
-    this.closeBoqModal();
-    this.updateUI();
-    this.emitFormStatus();
-    Toast.success('BOQ saved successfully');
+    // Prepare data for backend
+    const postData = {
+      building_uuid: buildingUuid,
+      mode: 'boq',
+      assembly_data: assemblyData
+    };
+
+    // If editing, include assembly_id
+    if (this.editingIndex !== null && this.boqItems[this.editingIndex]?.id) {
+      postData.assembly_id = this.boqItems[this.editingIndex].id;
+    }
+
+    try {
+      const response = await fetch("{% url 'building_step_structural' %}", {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': this.getCSRFToken()
+        },
+        body: JSON.stringify({
+          action: 'save_assembly',
+          ...postData
+        })
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        // Update local data with server response
+        const item = {
+          id: result.assembly.id,
+          name: name,
+          comment: assemblyData.comment,
+          materials: materials,
+          total_gwp: totalGwp
+        };
+
+        if (this.editingIndex !== null) {
+          this.boqItems[this.editingIndex] = item;
+        } else {
+          this.boqItems.push(item);
+        }
+
+        this.closeBoqModal();
+        this.updateUI();
+        this.emitFormStatus();
+        Toast.success('BOQ saved successfully');
+      } else {
+        Toast.error(result.error || 'Failed to save BOQ');
+      }
+    } catch (error) {
+      console.error('Error saving BOQ:', error);
+      Toast.error('Failed to save BOQ');
+    }
   }
 
-  saveComponent() {
+  async saveComponent() {
     const title = document.getElementById('component_title').value.trim();
     if (!title) {
       Toast.error('Please enter a component title');
@@ -680,29 +738,89 @@ class StructuralComponentManager {
 
     const totalGwp = materials.reduce((sum, m) => sum + (m.gwp * m.quantity), 0);
     const categorySelect = document.getElementById('component_category');
+    const category = document.getElementById('component_category').value;
+    const technique = document.getElementById('component_technique').value;
+    const dimension = document.getElementById('component_dimension').value;
+    const quantity = document.getElementById('component_quantity').value;
 
-    const item = {
+    const assemblyData = {
       title: title,
-      category: document.getElementById('component_category').value,
-      category_name: categorySelect.options[categorySelect.selectedIndex]?.text || '',
-      technique: document.getElementById('component_technique').value,
-      dimension: document.getElementById('component_dimension').value,
-      quantity: document.getElementById('component_quantity').value,
+      category: category,
+      technique: technique || null,
+      dimension: dimension,
+      quantity: parseFloat(quantity) || 1,
       comment: document.getElementById('component_comment').value,
-      materials: materials,
-      total_gwp: totalGwp
+      materials: materials
     };
 
-    if (this.editingIndex !== null) {
-      this.componentItems[this.editingIndex] = item;
-    } else {
-      this.componentItems.push(item);
+    // Get building UUID from URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const buildingUuid = urlParams.get('building_uuid');
+
+    if (!buildingUuid) {
+      Toast.error('Building UUID not found');
+      return;
     }
 
-    this.closeComponentModal();
-    this.updateUI();
-    this.emitFormStatus();
-    Toast.success('Component saved successfully');
+    // Prepare data for backend
+    const postData = {
+      building_uuid: buildingUuid,
+      mode: 'component',
+      assembly_data: assemblyData
+    };
+
+    // If editing, include assembly_id
+    if (this.editingIndex !== null && this.componentItems[this.editingIndex]?.id) {
+      postData.assembly_id = this.componentItems[this.editingIndex].id;
+    }
+
+    try {
+      const response = await fetch("{% url 'building_step_structural' %}", {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': this.getCSRFToken()
+        },
+        body: JSON.stringify({
+          action: 'save_assembly',
+          ...postData
+        })
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        // Update local data with server response
+        const item = {
+          id: result.assembly.id,
+          title: title,
+          category: category,
+          category_name: categorySelect.options[categorySelect.selectedIndex]?.text || '',
+          technique: technique,
+          dimension: dimension,
+          quantity: quantity,
+          comment: assemblyData.comment,
+          materials: materials,
+          total_gwp: totalGwp
+        };
+
+        if (this.editingIndex !== null) {
+          this.componentItems[this.editingIndex] = item;
+        } else {
+          this.componentItems.push(item);
+        }
+
+        this.closeComponentModal();
+        this.updateUI();
+        this.emitFormStatus();
+        Toast.success('Component saved successfully');
+      } else {
+        Toast.error(result.error || 'Failed to save component');
+      }
+    } catch (error) {
+      console.error('Error saving component:', error);
+      Toast.error('Failed to save component');
+    }
   }
 
   editItem(type, index) {
@@ -718,21 +836,63 @@ class StructuralComponentManager {
     structural_delete_modal.showModal();
   }
 
-  executeDelete() {
+  async executeDelete() {
     if (!this.pendingDelete) return;
 
     const { type, index } = this.pendingDelete;
-    if (type === 'boq') {
-      this.boqItems.splice(index, 1);
-    } else {
-      this.componentItems.splice(index, 1);
+    const items = type === 'boq' ? this.boqItems : this.componentItems;
+    const item = items[index];
+
+    // If item has an ID, delete from backend
+    if (item?.id) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const buildingUuid = urlParams.get('building_uuid');
+
+      if (!buildingUuid) {
+        Toast.error('Building UUID not found');
+        return;
+      }
+
+      try {
+        const response = await fetch("{% url 'building_step_structural' %}", {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': this.getCSRFToken()
+          },
+          body: JSON.stringify({
+            action: 'delete_assembly',
+            building_uuid: buildingUuid,
+            assembly_id: item.id
+          })
+        });
+
+        const result = await response.json();
+
+        if (!result.success) {
+          Toast.error(result.error || 'Failed to delete item');
+          return;
+        }
+      } catch (error) {
+        console.error('Error deleting item:', error);
+        Toast.error('Failed to delete item');
+        return;
+      }
     }
+
+    // Remove from local array
+    items.splice(index, 1);
 
     this.pendingDelete = null;
     structural_delete_modal.close();
     this.updateUI();
     this.emitFormStatus();
     Toast.info('Item removed');
+  }
+
+  getCSRFToken() {
+    return document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+           document.cookie.split('; ').find(row => row.startsWith('csrftoken='))?.split('=')[1] || '';
   }
 
   updateUI() {
@@ -839,6 +999,26 @@ const structuralManager = new StructuralComponentManager();
 
 // Initialize immediately since this template is loaded dynamically
 structuralManager.init();
+
+// Load saved data from backend if available
+{% if boq_items or component_items %}
+try {
+  const boqItemsEl = document.getElementById('boq-items-data');
+  const componentItemsEl = document.getElementById('component-items-data');
+
+  const boqItems = boqItemsEl ? JSON.parse(boqItemsEl.textContent) : [];
+  const componentItems = componentItemsEl ? JSON.parse(componentItemsEl.textContent) : [];
+
+  if (boqItems.length > 0 || componentItems.length > 0) {
+    structuralManager.restore({
+      boq_items: boqItems,
+      component_items: componentItems
+    });
+  }
+} catch (error) {
+  console.error('Error loading saved structural data:', error);
+}
+{% endif %}
 
 window.getStructuralFormData = () => structuralManager.getFormData();
 window.restoreStructuralData = (data) => structuralManager.restore(data);

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -1,5 +1,9 @@
 {% load static %}
 
+<!-- Hidden data for JavaScript restoration -->
+{{ boq_items|json_script:"boq-items-data" }}
+{{ component_items|json_script:"component-items-data" }}
+
 <div class="flex gap-2 p-2 rounded-lg bg-[var(--state--faded--lighter)]">
   <span data-icon="information-2-line" data-size="16" data-color="var(--icon--sub-600)"></span>
   If data is available as total quantity per material, select "Add from BoQ".
@@ -68,6 +72,13 @@
             <input type="text" id="boq_comment" placeholder="Add a comment" />
           </label>
         </fieldset>
+        <fieldset class="fieldset">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" id="boq_is_template" class="checkbox checkbox-sm" />
+            <span class="text-sm/5 font-medium">Save as template for future use</span>
+          </label>
+          <p class="text-xs/4 text-[var(--text--sub-600)] mt-1">Templates can be reused across multiple buildings</p>
+        </fieldset>
       </div>
 
       <h2 class="bg-[var(--bg--weak-50)] w-full px-5 py-1.5 text-[var(--text--sub-600)] text-xs/4 font-medium mb-4">
@@ -103,7 +114,7 @@
 
     <div class="p-5 flex items-center justify-end gap-4 border-t border-[var(--stroke--soft-200)]">
       <button type="button" class="btn btn-outline" onclick="structuralManager.closeBoqModal()">Cancel</button>
-      <button type="button" class="btn btn-primary" id="btn-save-boq" onclick="structuralManager.saveBoq()">Done</button>
+      <button type="button" class="btn btn-primary" id="btn-save-boq" onclick="structuralManager.saveBoq()">Save</button>
     </div>
   </div>
 </dialog>
@@ -128,11 +139,11 @@
         </fieldset>
         <fieldset class="fieldset">
           <legend class="fieldset-legend">Building Component</legend>
-          <select id="component_category" class="select w-full"
+          <select id="component_category" name="category_id" class="select w-full"
                   hx-get="{% url 'building_step_structural' %}?action=get_techniques"
                   hx-target="#component_technique"
                   hx-trigger="change"
-                  hx-include="[name='category_id']">
+                  hx-vals="js:{category_id: document.getElementById('component_category').value}">
             <option value="" selected disabled>Select component</option>
           </select>
         </fieldset>
@@ -163,6 +174,13 @@
           <label class="input w-full">
             <input type="text" id="component_comment" placeholder="Add a comment" />
           </label>
+        </fieldset>
+        <fieldset class="fieldset col-span-3">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" id="component_is_template" class="checkbox checkbox-sm" />
+            <span class="text-sm/5 font-medium">Save as template for future use</span>
+          </label>
+          <p class="text-xs/4 text-[var(--text--sub-600)] mt-1">Templates can be reused across multiple buildings</p>
         </fieldset>
       </div>
 
@@ -197,7 +215,7 @@
 
     <div class="p-5 flex items-center justify-end gap-4 border-t border-[var(--stroke--soft-200)]">
       <button type="button" class="btn btn-outline" onclick="structuralManager.closeComponentModal()">Cancel</button>
-      <button type="button" class="btn btn-primary" onclick="structuralManager.saveComponent()">Done</button>
+      <button type="button" class="btn btn-primary" onclick="structuralManager.saveComponent()">Save</button>
     </div>
   </div>
 </dialog>
@@ -220,7 +238,7 @@
       <div class="px-5 py-2.5 w-full">
         <form id="structural_epd_filter_form"
               hx-post="{% url 'building_step_structural' %}"
-              hx-vals='{"action": "filter"}'
+              hx-vals="js:{action: 'filter', mode: document.getElementById('epd_filter_mode').value, dimension: document.getElementById('epd_filter_dimension').value}"
               hx-target="#structural_epd_list"
               hx-swap="innerHTML"
               hx-trigger="submit, change from:select delay:300ms, keyup changed delay:500ms from:input[name='search_query']"
@@ -428,10 +446,12 @@
       const item = this.boqItems[index];
       document.getElementById('boq_name').value = item.name;
       document.getElementById('boq_comment').value = item.comment || '';
+      document.getElementById('boq_is_template').checked = item.is_template || false;
       this.renderMaterials(item.materials, 'boq');
     } else {
       document.getElementById('boq_name').value = '';
       document.getElementById('boq_comment').value = '';
+      document.getElementById('boq_is_template').checked = false;
       document.getElementById('structural_materials_list').innerHTML = '';
     }
 
@@ -457,6 +477,7 @@
       document.getElementById('component_dimension').value = item.dimension || 'area';
       document.getElementById('component_quantity').value = item.quantity || '';
       document.getElementById('component_comment').value = item.comment || '';
+      document.getElementById('component_is_template').checked = item.is_template || false;
       this.renderMaterials(item.materials, 'component');
     } else {
       document.getElementById('component_title').value = '';
@@ -465,6 +486,7 @@
       document.getElementById('component_dimension').value = 'area';
       document.getElementById('component_quantity').value = '';
       document.getElementById('component_comment').value = '';
+      document.getElementById('component_is_template').checked = false;
       document.getElementById('component_materials_list').innerHTML = '';
     }
 
@@ -517,10 +539,10 @@
     const list = document.getElementById(listId);
     if (!list) return [];
 
-    return Array.from(list.children).map(li => {
+    const materials = Array.from(list.children).map(li => {
       const epdId = li.dataset.epdId;
       const timestamp = li.dataset.timestamp;
-      return {
+      const material = {
         epd_id: epdId,
         name: li.dataset.name,
         gwp: parseFloat(li.dataset.gwp) || 0,
@@ -530,7 +552,11 @@
         category: li.querySelector('.material-category')?.value || '',
         timestamp: timestamp
       };
+      console.log(`[collectMaterials] Material collected:`, material);
+      return material;
     });
+    console.log(`[collectMaterials] Total materials from ${listId}:`, materials.length);
+    return materials;
   }
 
   validateMaterials(materials, mode) {
@@ -628,7 +654,7 @@
     this.updateMaterialsUI();
   }
 
-  saveBoq() {
+  async saveBoq() {
     const name = document.getElementById('boq_name').value.trim();
     if (!name) {
       Toast.error('Please enter a BOQ name');
@@ -655,22 +681,66 @@
       name: name,
       comment: document.getElementById('boq_comment').value,
       materials: materials,
-      total_gwp: totalGwp
+      total_gwp: totalGwp,
+      is_template: document.getElementById('boq_is_template').checked
     };
 
-    if (this.editingIndex !== null) {
-      this.boqItems[this.editingIndex] = item;
-    } else {
-      this.boqItems.push(item);
+    // Save to database via API
+    const buildingUuid = new URLSearchParams(window.location.search).get('building_uuid');
+    if (!buildingUuid) {
+      Toast.error('Building UUID not found');
+      return;
     }
 
-    this.closeBoqModal();
-    this.updateUI();
-    this.emitFormStatus();
-    Toast.success('BOQ saved successfully');
+    const saveBtn = document.getElementById('btn-save-boq');
+    const originalText = saveBtn.innerHTML;
+    saveBtn.disabled = true;
+    saveBtn.innerHTML = '<span class="loading loading-spinner loading-sm"></span> Saving...';
+
+    try {
+      const response = await fetch('{% url "building_step_structural" %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]')?.value || ''
+        },
+        body: JSON.stringify({
+          action: 'save_assembly',
+          building_uuid: buildingUuid,
+          mode: 'boq',
+          assembly_data: item
+        })
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        // Store assembly ID for editing
+        item.id = result.assembly.id;
+
+        if (this.editingIndex !== null) {
+          this.boqItems[this.editingIndex] = item;
+        } else {
+          this.boqItems.push(item);
+        }
+
+        this.closeBoqModal();
+        this.updateUI();
+        this.emitFormStatus();
+        Toast.success('BOQ saved to database successfully');
+      } else {
+        Toast.error(result.error || 'Failed to save BOQ');
+      }
+    } catch (error) {
+      console.error('Error saving BOQ:', error);
+      Toast.error('Failed to save BOQ');
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.innerHTML = originalText;
+    }
   }
 
-  saveComponent() {
+  async saveComponent() {
     const title = document.getElementById('component_title').value.trim();
     if (!title) {
       Toast.error('Please enter a component title');
@@ -703,19 +773,63 @@
       quantity: document.getElementById('component_quantity').value,
       comment: document.getElementById('component_comment').value,
       materials: materials,
-      total_gwp: totalGwp
+      total_gwp: totalGwp,
+      is_template: document.getElementById('component_is_template').checked
     };
 
-    if (this.editingIndex !== null) {
-      this.componentItems[this.editingIndex] = item;
-    } else {
-      this.componentItems.push(item);
+    // Save to database via API
+    const buildingUuid = new URLSearchParams(window.location.search).get('building_uuid');
+    if (!buildingUuid) {
+      Toast.error('Building UUID not found');
+      return;
     }
 
-    this.closeComponentModal();
-    this.updateUI();
-    this.emitFormStatus();
-    Toast.success('Component saved successfully');
+    const saveBtn = document.querySelector('#structural_component_modal .btn-primary');
+    const originalText = saveBtn.innerHTML;
+    saveBtn.disabled = true;
+    saveBtn.innerHTML = '<span class="loading loading-spinner loading-sm"></span> Saving...';
+
+    try {
+      const response = await fetch('{% url "building_step_structural" %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]')?.value || ''
+        },
+        body: JSON.stringify({
+          action: 'save_assembly',
+          building_uuid: buildingUuid,
+          mode: 'component',
+          assembly_data: item
+        })
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        // Store assembly ID for editing
+        item.id = result.assembly.id;
+
+        if (this.editingIndex !== null) {
+          this.componentItems[this.editingIndex] = item;
+        } else {
+          this.componentItems.push(item);
+        }
+
+        this.closeComponentModal();
+        this.updateUI();
+        this.emitFormStatus();
+        Toast.success('Component saved to database successfully');
+      } else {
+        Toast.error(result.error || 'Failed to save component');
+      }
+    } catch (error) {
+      console.error('Error saving component:', error);
+      Toast.error('Failed to save component');
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.innerHTML = originalText;
+    }
   }
 
   editItem(type, index) {
@@ -731,10 +845,49 @@
     structural_delete_modal.showModal();
   }
 
-  executeDelete() {
+  async executeDelete() {
     if (!this.pendingDelete) return;
 
     const { type, index } = this.pendingDelete;
+    const items = type === 'boq' ? this.boqItems : this.componentItems;
+    const item = items[index];
+
+    // If item has an ID, delete from database
+    if (item && item.id) {
+      const buildingUuid = new URLSearchParams(window.location.search).get('building_uuid');
+      if (!buildingUuid) {
+        Toast.error('Building UUID not found');
+        return;
+      }
+
+      try {
+        const response = await fetch('{% url "building_step_structural" %}', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]')?.value || ''
+          },
+          body: JSON.stringify({
+            action: 'delete_assembly',
+            building_uuid: buildingUuid,
+            assembly_id: item.id
+          })
+        });
+
+        const result = await response.json();
+
+        if (!result.success) {
+          Toast.error(result.error || 'Failed to delete');
+          return;
+        }
+      } catch (error) {
+        console.error('Error deleting assembly:', error);
+        Toast.error('Failed to delete from database');
+        return;
+      }
+    }
+
+    // Remove from local array
     if (type === 'boq') {
       this.boqItems.splice(index, 1);
     } else {
@@ -745,7 +898,7 @@
     structural_delete_modal.close();
     this.updateUI();
     this.emitFormStatus();
-    Toast.info('Item removed');
+    Toast.success('Item deleted successfully');
   }
 
   updateUI() {
@@ -856,5 +1009,23 @@
 
   window.getStructuralFormData = () => window.structuralManager.getFormData();
   window.restoreStructuralData = (data) => window.structuralManager.restore(data);
+
+  // Restore data from server if available (for edit mode)
+  {% if boq_items or component_items %}
+    console.log('[StructuralComponents] Restoring data from server');
+    try {
+      const boqItemsJson = document.getElementById('boq-items-data')?.textContent;
+      const componentItemsJson = document.getElementById('component-items-data')?.textContent;
+
+      const serverData = {
+        boq_items: boqItemsJson ? JSON.parse(boqItemsJson) : [],
+        component_items: componentItemsJson ? JSON.parse(componentItemsJson) : []
+      };
+      console.log('[StructuralComponents] Server data:', serverData);
+      window.structuralManager.restore(serverData);
+    } catch (error) {
+      console.error('[StructuralComponents] Error restoring data:', error);
+    }
+  {% endif %}
 })();
 </script>

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -774,11 +774,13 @@
 
           if (epdId) {
             // Use the proper EPD selection endpoint to add the material
+            // Use current dimension from the dropdown, not template dimension
+            const currentDimension = document.getElementById('component_dimension').value;
             const formData = new FormData();
             formData.append('action', 'select_structural_product');
             formData.append('epd_id', epdId);
             formData.append('mode', 'component');
-            formData.append('dimension', template.dimension || 'area');
+            formData.append('dimension', currentDimension);
 
             const response = await fetch('{% url "building_step_structural" %}', {
               method: 'POST',
@@ -860,7 +862,7 @@
         gwp: parseFloat(li.dataset.gwp) || 0,
         description: li.querySelector('.material-description')?.value || '',
         quantity: parseFloat(li.querySelector('.material-quantity')?.value) || 0,
-        unit: li.querySelector('.material-unit')?.value || '',
+        unit: li.querySelector('.material-unit-value')?.value || li.querySelector('.material-unit')?.dataset?.unit || '',
         category: li.querySelector('.material-category')?.value || '',
         timestamp: timestamp
       };

--- a/templates/pages/add-building/components/operational-data-entry/_form_section.html
+++ b/templates/pages/add-building/components/operational-data-entry/_form_section.html
@@ -1,6 +1,6 @@
 <form id="operational-products-form"
       hx-post="{% url 'building_step_operational' %}"
-      hx-vals='{"action": "save_op_products"}'
+      hx-vals='js:{"action": "save_op_products", "building_uuid": new URLSearchParams(window.location.search).get("building_uuid")}'
       hx-target="#operational-products-form"
       hx-swap="outerHTML">
   <ul class="grid grid-cols-1 gap-2" id="selected_op_products">

--- a/templates/pages/add-building/components/operational-data-entry/_form_section.html
+++ b/templates/pages/add-building/components/operational-data-entry/_form_section.html
@@ -2,7 +2,8 @@
       hx-post="{% url 'building_step_operational' %}"
       hx-vals='js:{"action": "save_op_products", "building_uuid": new URLSearchParams(window.location.search).get("building_uuid")}'
       hx-target="#operational-products-form"
-      hx-swap="outerHTML">
+      hx-swap="outerHTML"
+      data-saved="true">
   <ul class="grid grid-cols-1 gap-2" id="selected_op_products">
     {% if selected_products %}
       {% for epd in selected_products %}
@@ -12,13 +13,14 @@
   </ul>
   
   <div class="flex items-center gap-2 mt-4" id="save_button_container" {% if not selected_products %}hidden{% endif %}>
-    <button 
-      type="submit" 
-      class="btn btn-sm btn-primary" 
+    <button
+      type="submit"
+      class="btn btn-sm btn-primary"
       id="save_button"
     >
-      <span data-icon="save-line" data-size="16" data-color="currentColor"></span>
-      Save Energy Carriers
+      <span data-icon="save-line" data-size="16" data-color="currentColor" class="button-icon"></span>
+      <span class="loading loading-spinner loading-xs button-loading hidden"></span>
+      <span class="button-text">Save Energy Carriers</span>
     </button>
     <span class="text-xs text-[var(--text--sub-600)]" id="save_status"></span>
   </div>

--- a/templates/pages/add-building/components/operational-data-entry/_selected_product.html
+++ b/templates/pages/add-building/components/operational-data-entry/_selected_product.html
@@ -66,10 +66,8 @@
         </div>
         <div class="flex items-center gap-3">
           <button
-            class="btn size-5 btn-ghost p-0"
-            onclick="energy_carrier_modal_delete.showModal()"
             type="button"
-            class="btn btn-ghost btn-sm btn-square remove-epd"
+            class="btn size-5 btn-ghost p-0 remove-epd"
             data-epd-id="{{ epd.id }}"
             data-timestamp="{{ epd.timestamp }}"
             data-element-id="epd-{{ epd.id }}-{{ epd.timestamp }}"

--- a/templates/pages/add-building/components/operational-data-entry/_selected_product.html
+++ b/templates/pages/add-building/components/operational-data-entry/_selected_product.html
@@ -1,11 +1,9 @@
 {% load custom_filters %}
 
-<form>
-  {% csrf_token %}
-  <li
-        class="flex items-center justify-between gap-1.5 w-full p-2.5 rounded-[var(--radius-8)] bg-[var(--bg--weak-50)] border border-[var(--stroke--soft-200)]"
-      id="epd-{{ epd.id }}-{{ epd.timestamp }}"
-        >
+<li
+      class="flex items-center justify-between gap-1.5 w-full p-2.5 rounded-[var(--radius-8)] bg-[var(--bg--weak-50)] border border-[var(--stroke--soft-200)]"
+    id="epd-{{ epd.id }}-{{ epd.timestamp }}"
+      >
         <span
           data-icon="gas-station-line"
           data-size="20"
@@ -26,20 +24,27 @@
           <div class="grid grid-cols-2 items-stretch gap-2 mt-1">
             <fieldset>
               <label class="input w-full validator">
-              <input  
-                name="description" 
+              <input
+                name="material_{{ epd.id }}_description_{{ epd.timestamp }}"
                 value="{% if epd.description %}{{ epd.description }}{% endif %}"
                 type="text" placeholder="Add a description"  required class="block w-full" />
               </label>
               <p class="validator-hint hidden">required</p>
             </fieldset>
-            
+
             <fieldset>
               <label class="input pr-0 grid grid-cols-2 validator">
-              <input type="number" name='quantity' class='block w-full' placeholder="Quantity" required min="1"  />
+              <input type="number"
+                name='material_{{ epd.id }}_quantity_{{ epd.timestamp }}'
+                value="{% if epd.selection_quantity %}{{ epd.selection_quantity }}{% endif %}"
+                class='block w-full'
+                placeholder="Quantity"
+                required
+                min="1"
+                step="0.01" />
               <select
                 class="select select-ghost w-fit !outline-none !border-none block w-full"
-                name="unit"
+                name="material_{{ epd.id }}_unit_{{ epd.timestamp }}"
                 required
               >
                 {% for unit in epd.op_units %}
@@ -78,7 +83,6 @@
           </button>
         </div>
       </li>
-</form>
 
 
 

--- a/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
+++ b/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
@@ -324,8 +324,8 @@
 </dialog>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-
+(function() {
+  // Use IIFE to avoid polluting global scope but allow re-execution on dynamic load
 
   const selectedOpProducts = document.getElementById('selected_op_products');
   const selectEpdText = document.getElementById('select_epd_text');
@@ -360,37 +360,97 @@ document.addEventListener('DOMContentLoaded', function() {
   // Handle Remove EPD button clicks
   if (selectedOpProducts) {
     selectedOpProducts.addEventListener('click', function(event) {
+      console.log('[Operational] Click event detected', event.target);
       const removeBtn = event.target.closest('.remove-epd');
+      console.log('[Operational] Remove button found:', removeBtn);
       if (removeBtn) {
         epdToDelete = {
           id: removeBtn.dataset.epdId,
           timestamp: removeBtn.dataset.timestamp,
           elementId: removeBtn.dataset.elementId
         };
-        deleteModal.showModal();
+        console.log('[Operational] EPD to delete:', epdToDelete);
+        console.log('[Operational] Delete modal:', deleteModal);
+        if (deleteModal) {
+          deleteModal.showModal();
+        } else {
+          console.error('[Operational] Delete modal not found!');
+        }
       }
     });
+  } else {
+    console.error('[Operational] selectedOpProducts element not found!');
   }
   
   // Handle delete confirmation
   const confirmDeleteBtn = document.getElementById('confirm-delete-btn');
   if (confirmDeleteBtn) {
-    confirmDeleteBtn.addEventListener('click', function() {
+    confirmDeleteBtn.addEventListener('click', async function() {
       if (epdToDelete) {
-        const epdElement = document.getElementById(epdToDelete.elementId);
-        if (epdElement) {
-          epdElement.remove();
-          updateUI();
-          // Mark form as unsaved since a product was removed
-          const form = document.getElementById('operational-products-form');
-          if (form) {
-            form.removeAttribute('data-saved');
-          }
-          Toast.info('Energy carrier removed. Click "Save Energy Carriers" to apply changes.');
+        const buildingUuid = new URLSearchParams(window.location.search).get('building_uuid');
+
+        if (!buildingUuid) {
+          Toast.error('Building UUID not found');
+          deleteModal.close();
+          return;
         }
-        epdToDelete = null;
+
+        // Disable button during request
+        confirmDeleteBtn.disabled = true;
+        confirmDeleteBtn.innerHTML = '<span class="loading loading-spinner loading-sm"></span> Removing...';
+
+        try {
+          const response = await fetch('{% url "building_step_operational" %}', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+                             document.cookie.split('; ').find(row => row.startsWith('csrftoken='))?.split('=')[1] || ''
+            },
+            body: JSON.stringify({
+              action: 'delete_op_product',
+              building_uuid: buildingUuid,
+              epd_id: epdToDelete.id
+            })
+          });
+
+          console.log('[Operational] Response status:', response.status);
+          console.log('[Operational] Response content-type:', response.headers.get('content-type'));
+
+          // Check if response is JSON
+          const contentType = response.headers.get('content-type');
+          if (!contentType || !contentType.includes('application/json')) {
+            const text = await response.text();
+            console.error('[Operational] Server returned non-JSON response:', text.substring(0, 500));
+            Toast.error('Server error: Expected JSON response');
+            return;
+          }
+
+          const result = await response.json();
+          console.log('[Operational] Delete result:', result);
+
+          if (result.success) {
+            // Remove element from DOM
+            const epdElement = document.getElementById(epdToDelete.elementId);
+            if (epdElement) {
+              epdElement.remove();
+              updateUI();
+            }
+            Toast.success('Energy carrier removed successfully');
+          } else {
+            Toast.error(result.error || 'Failed to remove energy carrier');
+          }
+        } catch (error) {
+          console.error('Error removing energy carrier:', error);
+          Toast.error('Failed to remove energy carrier: ' + error.message);
+        } finally {
+          // Reset button
+          confirmDeleteBtn.disabled = false;
+          confirmDeleteBtn.innerHTML = 'Remove';
+          epdToDelete = null;
+          deleteModal.close();
+        }
       }
-      deleteModal.close();
     });
   }
   
@@ -463,7 +523,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Initialize UI on load
   updateUI();
-});
+})();
 </script>
 
 <!-- Remove old templates as they're not needed with Django rendering -->

--- a/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
+++ b/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
@@ -34,7 +34,7 @@
     <!-- Selected Products Container -->
     <form id="operational-products-form"
           hx-post="{% url 'building_step_operational' %}"
-          hx-vals='{"action": "save_op_products"}'
+          hx-vals='js:{"action": "save_op_products", "building_uuid": new URLSearchParams(window.location.search).get("building_uuid")}'
           hx-target="#operational-products-form"
           hx-swap="outerHTML">
 

--- a/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
+++ b/templates/pages/add-building/components/operational-data-entry/operational-data-entry.html
@@ -36,7 +36,9 @@
           hx-post="{% url 'building_step_operational' %}"
           hx-vals='js:{"action": "save_op_products", "building_uuid": new URLSearchParams(window.location.search).get("building_uuid")}'
           hx-target="#operational-products-form"
-          hx-swap="outerHTML">
+          hx-swap="outerHTML"
+          {% if selected_products %}data-saved="true"{% endif %}>
+      {% csrf_token %}
 
       <ul class="grid grid-cols-1 gap-2" id="selected_op_products">
         {% if selected_products %}
@@ -71,13 +73,14 @@
       </ul>
       
       <div class="flex items-center gap-2 mt-4" id="save_button_container" {% if not selected_products %}hidden{% endif %}>
-        <button 
-          type="submit" 
-          class="btn btn-sm btn-primary" 
+        <button
+          type="submit"
+          class="btn btn-sm btn-primary"
           id="save_button"
         >
-          <span data-icon="save-line" data-size="16" data-color="currentColor"></span>
-          Save Energy Carriers
+          <span data-icon="save-line" data-size="16" data-color="currentColor" class="button-icon"></span>
+          <span class="loading loading-spinner loading-xs button-loading hidden"></span>
+          <span class="button-text">Save Energy Carriers</span>
         </button>
         <span class="text-xs text-[var(--text--sub-600)]" id="save_status"></span>
       </div>
@@ -321,6 +324,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const saveButtonContainer = document.getElementById('save_button_container');
   const deleteModal = document.getElementById('energy_carrier_modal_delete');
   const mainModal = document.getElementById('energy_carrier_modal');
+  const saveButton = document.getElementById('save_button');
   let epdToDelete = null;
   
   // Update UI based on selected products count
@@ -334,8 +338,13 @@ document.addEventListener('DOMContentLoaded', function() {
   document.body.addEventListener('htmx:afterSwap', function(event) {
     if (event.detail.target.id === 'selected_op_products') {
       updateUI();
+      // Mark form as unsaved since a new product was added
+      const form = document.getElementById('operational-products-form');
+      if (form) {
+        form.removeAttribute('data-saved');
+      }
       // Close modal after adding
-      Toast.info('Energy carrier added successfully');
+      Toast.info('Energy carrier added successfully. Click "Save Energy Carriers" to apply changes.');
       if (mainModal) mainModal.close();
     }
   });
@@ -359,12 +368,17 @@ document.addEventListener('DOMContentLoaded', function() {
   const confirmDeleteBtn = document.getElementById('confirm-delete-btn');
   if (confirmDeleteBtn) {
     confirmDeleteBtn.addEventListener('click', function() {
-      energy_carrier_modal_delete.open();
       if (epdToDelete) {
         const epdElement = document.getElementById(epdToDelete.elementId);
         if (epdElement) {
           epdElement.remove();
           updateUI();
+          // Mark form as unsaved since a product was removed
+          const form = document.getElementById('operational-products-form');
+          if (form) {
+            form.removeAttribute('data-saved');
+          }
+          Toast.info('Energy carrier removed. Click "Save Energy Carriers" to apply changes.');
         }
         epdToDelete = null;
       }
@@ -372,21 +386,73 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
   
-  // Handle successful save
-  document.body.addEventListener('htmx:afterRequest', function(event) {
-    if (event.detail.target.id === 'operational-products-form' && event.detail.successful) {
-      const saveStatus = document.getElementById('save_status');
-      if (saveStatus) {
-        saveStatus.textContent = 'Saved successfully!';
-        saveStatus.classList.add('text-success');
-        setTimeout(() => {
-          saveStatus.textContent = '';
-          saveStatus.classList.remove('text-success');
-        }, 3000);
+  // Handle save button loading state
+  document.body.addEventListener('htmx:beforeRequest', function(event) {
+    if (event.detail.target.id === 'operational-products-form') {
+      const btn = document.getElementById('save_button');
+      if (btn) {
+        btn.disabled = true;
+        const icon = btn.querySelector('.button-icon');
+        const loading = btn.querySelector('.button-loading');
+        const text = btn.querySelector('.button-text');
+        if (icon) icon.classList.add('hidden');
+        if (loading) loading.classList.remove('hidden');
+        if (text) text.textContent = 'Saving...';
       }
     }
   });
-  
+
+  // Handle successful save
+  document.body.addEventListener('htmx:afterRequest', function(event) {
+    if (event.detail.target.id === 'operational-products-form') {
+      const btn = document.getElementById('save_button');
+      if (btn) {
+        btn.disabled = false;
+        const icon = btn.querySelector('.button-icon');
+        const loading = btn.querySelector('.button-loading');
+        const text = btn.querySelector('.button-text');
+        if (icon) icon.classList.remove('hidden');
+        if (loading) loading.classList.add('hidden');
+        if (text) text.textContent = 'Save Energy Carriers';
+      }
+
+      if (event.detail.successful) {
+        // Mark form as saved
+        const form = document.getElementById('operational-products-form');
+        if (form) {
+          form.dataset.saved = 'true';
+        }
+
+        const saveStatus = document.getElementById('save_status');
+        if (saveStatus) {
+          saveStatus.textContent = 'Saved successfully!';
+          saveStatus.classList.add('text-success');
+          setTimeout(() => {
+            saveStatus.textContent = '';
+            saveStatus.classList.remove('text-success');
+          }, 3000);
+        }
+        Toast.success('Energy carriers saved successfully');
+      }
+    }
+  });
+
+  // Mark form as unsaved when any field changes
+  if (selectedOpProducts) {
+    selectedOpProducts.addEventListener('input', function(event) {
+      const form = document.getElementById('operational-products-form');
+      if (form && form.dataset.saved === 'true') {
+        form.removeAttribute('data-saved');
+        const saveStatus = document.getElementById('save_status');
+        if (saveStatus) {
+          saveStatus.textContent = 'Unsaved changes';
+          saveStatus.classList.remove('text-success');
+          saveStatus.classList.add('text-warning');
+        }
+      }
+    });
+  }
+
   // Initialize UI on load
   updateUI();
 });

--- a/templates/pages/add-building/components/operational-details/operational-schedule-temperature.html
+++ b/templates/pages/add-building/components/operational-details/operational-schedule-temperature.html
@@ -87,3 +87,66 @@
   </div>
 
 </form>
+
+<script>
+(function() {
+  const form = document.getElementById('form');
+  const buildingUuid = new URLSearchParams(window.location.search).get('building_uuid');
+
+  // Load existing data on page load
+  async function loadExistingData() {
+    if (!buildingUuid) {
+      console.warn('[OperationalSchedule] No building UUID found');
+      return;
+    }
+
+    try {
+      const response = await fetch(`{% url 'building_step_operational_schedule' %}?building_uuid=${buildingUuid}`);
+      if (!response.ok) {
+        console.error('[OperationalSchedule] Failed to load data');
+        return;
+      }
+
+      const result = await response.json();
+      console.log('[OperationalSchedule] Loaded data:', result);
+
+      if (result.success && result.data) {
+        const data = result.data;
+
+        // Populate form fields
+        if (data.number_of_residents) {
+          form.querySelector('[name="number_of_residents"]').value = data.number_of_residents;
+        }
+        if (data.annual_operating_hours_per_day) {
+          form.querySelector('[name="annual_operating_hours_per_day"]').value = data.annual_operating_hours_per_day;
+        }
+        if (data.annual_operating_days_per_week) {
+          form.querySelector('[name="annual_operating_days_per_week"]').value = data.annual_operating_days_per_week;
+        }
+        if (data.annual_operating_weeks_per_year) {
+          form.querySelector('[name="annual_operating_weeks_per_year"]').value = data.annual_operating_weeks_per_year;
+        }
+        if (data.room_heating_temperature) {
+          form.querySelector('[name="room_heating_temperature"]').value = data.room_heating_temperature;
+        }
+        if (data.heating_temperature_unit) {
+          form.querySelector('[name="heating_temperature_unit"]').value = data.heating_temperature_unit;
+        }
+        if (data.room_cooling_temperature) {
+          form.querySelector('[name="room_cooling_temperature"]').value = data.room_cooling_temperature;
+        }
+        if (data.cooling_temperature_unit) {
+          form.querySelector('[name="cooling_temperature_unit"]').value = data.cooling_temperature_unit;
+        }
+
+        console.log('[OperationalSchedule] Data loaded successfully');
+      }
+    } catch (error) {
+      console.error('[OperationalSchedule] Error loading data:', error);
+    }
+  }
+
+  // Load existing data when page loads
+  loadExistingData();
+})();
+</script>


### PR DESCRIPTION
# Integration of Operational Data Entry, Structural Components, and Operational Schedule

## Summary

This PR implements complete functionality for three critical building wizard steps:
1. **Operational Data Entry** - Energy carriers selection and management
2. **Structural Components** - Building materials and assemblies
3. **Operational Schedule & Temperature** - Building operation parameters

All steps now support full CRUD operations with proper data persistence, validation, and user feedback.


## Changes Made

### 1. Operational Data Entry - Energy Carriers

#### Fixed Remove Button Functionality
- **Issue**: Remove button on energy carriers wasn't working - no API calls were made
- **Root Cause**: Duplicate class attributes and missing backend endpoint
- **Solution**:
  - Created `handle_delete_product()` endpoint in `building_step_operational.py`
  - Fixed button markup in `_selected_product.html` (removed duplicate classes)
  - Implemented proper async delete with confirmation modal
  - Shows loading state during deletion
  - Displays success/error toasts

**Files Changed**:
- `pages/views/building/building_step_operational.py`
  - Added `handle_delete_product()` function
  - Updated main view to handle `delete_op_product` action from JSON body
- `templates/pages/add-building/components/operational-data-entry/_selected_product.html`
  - Cleaned up button markup (removed duplicate class declarations)
- `templates/pages/add-building/components/operational-data-entry/operational-data-entry.html`
  - Updated delete confirmation handler to call API endpoint
  - Added loading states and error handling
  - Changed from IIFE to immediate execution for dynamic loading compatibility

### 2. Structural Components - Unit Validation Fix

#### Fixed Unit Validation Errors
- **Issue**: Getting unit validation errors when creating/editing components:
  - `"The unit 'kg' is not valid for the epd 'Steel section'. Expected unit: 'cm'"`
  - Error occurred even with fresh components, not just templates
- **Root Cause**:
  - Frontend showed dropdown with all available EPD units (kg, m³, etc.)
  - Backend expected specific unit based on dimension (cm for area, percent for mass, etc.)
  - User could select incompatible units from dropdown
- **Solution**:
  - Removed unit selection dropdown
  - Now displays only the recommended `selection_unit` as read-only text
  - Unit is automatically determined by dimension and EPD type
  - Added hidden input to store the correct unit value

**Files Changed**:
- `templates/pages/add-building/components/building-structural-components/_selected_material.html`
  - Replaced `<select class="material-unit">` with `<span>` + hidden input
  - Unit is now `{{ epd.selection_unit }}` (read-only display)
- `templates/pages/add-building/components/building-structural-components/building-structural-components.html`
  - Updated `collectMaterials()` to read from `.material-unit-value` hidden input
  - Fixed template loading to use current dimension instead of template dimension (line 781)

**Dimension-Unit Mapping** (from `epd_dimension_info.py`):
- `dimension=area` → `unit=cm` (layer thickness)
- `dimension=mass` → `unit=percent` (share of mass)
- `dimension=volume` → `unit=percent` (share of volume)
- `dimension=length` → `unit=cm²` (cross-section)

**Backend Validation** (unchanged):
- `StructuralProduct.clean()` validates `input_unit` matches expected unit from `get_epd_info()`

---

### 3. Operational Schedule & Temperature - Full Implementation

#### Created Complete Save/Load Functionality
- **Issue**: No backend endpoint or save mechanism existed
- **Solution**: Built complete CRUD system with custom endpoint


**Frontend**:

Updated `operational-schedule-temperature.html`:
- Added JavaScript to fetch existing data on page load
- Populates form fields automatically
- Logs load success/failure to console

**Step Manager Integration**:

Updated `libs/step-manager.js` (and `static/js/step-manager.js`):
- Added special handling in `getFormData()` for `operational-details/operational-schedule-temperature`
- Returns data with `_useCustomEndpoint: true` marker
- Modified `saveToServer()` to detect custom endpoints and route accordingly
- Custom endpoints bypass generic `/building/step/save` flow




## Files Modified

### Backend
- `pages/views/building/building_step_operational.py` - Added delete endpoint
- `pages/views/building/building_step_operational_schedule.py` - **NEW FILE**
- `pages/urls.py` - Added operational-schedule route

### Frontend Templates
- `templates/pages/add-building/components/operational-data-entry/operational-data-entry.html`
- `templates/pages/add-building/components/operational-data-entry/_selected_product.html`
- `templates/pages/add-building/components/building-structural-components/_selected_material.html`
- `templates/pages/add-building/components/building-structural-components/building-structural-components.html`
- `templates/pages/add-building/components/operational-details/operational-schedule-temperature.html`
- `templates/pages/add-building/components/building-information/building-details.html`

### JavaScript
- `libs/step-manager.js` - Added custom endpoint handling
- `static/js/step-manager.js` - Synced with libs version
