### PR TITLE
hot fix: Split/VRV units required but was optional

### DIFF
--- a/templates/pages/add-building/components/operational-details/cooling-system.html
+++ b/templates/pages/add-building/components/operational-details/cooling-system.html
@@ -612,6 +612,15 @@
         </div>
       </div>
     </fieldset>
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">
+        Total number of split/VRV units<span class="text-[var(--state--error--base)]">*</span>
+      </legend>
+      <label class="input validator w-full">
+        <input type="number" placeholder="e.g. 2" name="total_number_of_split_vrv_units" required min="1" />
+      </label>
+      <p class="validator-hint">This field is required</p>
+    </fieldset>
     <div class="col-span-2 mt-3">
       <div class="collapse rounded-none">
         <input type="checkbox" class="peer" />
@@ -628,14 +637,6 @@
         </div>
         <div class="collapse-content mt-4 px-0">
           <div class="grid grid-cols-2 gap-2">
-            <fieldset class="fieldset">
-              <legend class="fieldset-legend">
-                Total number of split/VRV units
-              </legend>
-              <label class="input w-full">
-                <input type="number" placeholder="e.g. 2" name="total_number_of_split_vrv_units" />
-              </label>
-            </fieldset>
             <fieldset class="fieldset">
               <legend class="fieldset-legend">
                 Total split unit//VRV system


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                          
  - Fix cryptic `number_of_units` required field error when saving a cooling system (Split/VRV air conditioner) without opening the "Other Details" section — moved "Total number of   split/VRV units" out of the collapsed section into the main form body and marked it as required
