### PR TITLE
 Make auto-calculated fields readonly across ventilation and lighting systems

### DIFF
--- a/templates/pages/add-building/components/operational-details/lighting-system.html
+++ b/templates/pages/add-building/components/operational-details/lighting-system.html
@@ -136,18 +136,20 @@
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total lighting power<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input w-full">
-        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" onchange="recalcLightingLPD()" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Fixtures × Wattage ÷ 1000</p>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline Lighting Power Density (LPD)</legend>
-      <label class="input w-full">
-        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW/m²</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Total lighting power ÷ Area of room</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
@@ -155,19 +157,19 @@
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" />
+            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">hrs / day</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" />
+            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" />
+            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
           </label>
         </div>
@@ -177,8 +179,8 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Installation of sensors<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" onchange="recalcLightingEnergy()" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked onchange="recalcLightingEnergy()" /> No</label>
       </div>
     </fieldset>
 
@@ -191,11 +193,12 @@
       <div class="collapse-content px-4 grid grid-cols-2 gap-x-2.5 gap-y-1">
 
         <fieldset class="fieldset col-span-2">
-          <legend class="fieldset-legend">Total energy consumption annually</legend>
-          <label class="input w-full">
-            <input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" />
+          <legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+          <label class="input w-full bg-[var(--bg--weak-50)]">
+            <input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span>
           </label>
+          <p class="label-text-alt text-[var(--text--soft-400)]">Total power (kW) × hrs/day × days/wk × wks/yr × sensor factor</p>
         </fieldset>
 
         <fieldset class="fieldset">
@@ -255,18 +258,20 @@
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total lighting power<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input w-full">
-        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" onchange="recalcLightingLPD()" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Fixtures × Tubes × Wattage ÷ 1000</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Baseline Lighting Power Density (LPD)</legend>
-      <label class="input w-full">
-        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW/m²</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Total lighting power ÷ Area of room</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
@@ -274,19 +279,19 @@
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" />
+            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">hrs / day</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" />
+            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" />
+            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
           </label>
         </div>
@@ -296,8 +301,8 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Installation of sensors<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" onchange="recalcLightingEnergy()" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked onchange="recalcLightingEnergy()" /> No</label>
       </div>
     </fieldset>
 
@@ -310,11 +315,12 @@
       <div class="collapse-content px-4 grid grid-cols-2 gap-x-2.5 gap-y-1">
 
         <fieldset class="fieldset col-span-2">
-          <legend class="fieldset-legend">Total energy consumption annually</legend>
-          <label class="input w-full">
-            <input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" />
+          <legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+          <label class="input w-full bg-[var(--bg--weak-50)]">
+            <input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span>
           </label>
+          <p class="label-text-alt text-[var(--text--soft-400)]">Total power (kW) × hrs/day × days/wk × wks/yr × sensor factor</p>
         </fieldset>
 
         <fieldset class="fieldset">
@@ -367,18 +373,20 @@
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total lighting power<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input w-full">
-        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" onchange="recalcLightingLPD()" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Fixtures × Wattage ÷ 1000</p>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline Lighting Power Density (LPD)</legend>
-      <label class="input w-full">
-        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW/m²</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Total lighting power ÷ Area of room</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
@@ -386,19 +394,19 @@
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" />
+            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">hrs / day</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" />
+            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" />
+            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
           </label>
         </div>
@@ -408,8 +416,8 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Installation of sensors<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" onchange="recalcLightingEnergy()" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked onchange="recalcLightingEnergy()" /> No</label>
       </div>
     </fieldset>
 
@@ -422,11 +430,12 @@
       <div class="collapse-content px-4 grid grid-cols-2 gap-x-2.5 gap-y-1">
 
         <fieldset class="fieldset col-span-2">
-          <legend class="fieldset-legend">Total energy consumption annually</legend>
-          <label class="input w-full">
-            <input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" />
+          <legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+          <label class="input w-full bg-[var(--bg--weak-50)]">
+            <input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span>
           </label>
+          <p class="label-text-alt text-[var(--text--soft-400)]">Total power (kW) × hrs/day × days/wk × wks/yr × sensor factor</p>
         </fieldset>
 
         <fieldset class="fieldset">
@@ -479,18 +488,20 @@
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total lighting power<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input w-full">
-        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" onchange="recalcLightingLPD()" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Fixtures × Wattage ÷ 1000</p>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline Lighting Power Density (LPD)</legend>
-      <label class="input w-full">
-        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW/m²</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Total lighting power ÷ Area of room</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
@@ -498,19 +509,19 @@
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" />
+            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">hrs / day</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" />
+            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" />
+            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
           </label>
         </div>
@@ -520,8 +531,8 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Installation of sensors<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="yes" class="radio radio-xs" onchange="recalcLightingEnergy()" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="installation_of_sensors" value="no" class="radio radio-xs" checked onchange="recalcLightingEnergy()" /> No</label>
       </div>
     </fieldset>
 
@@ -534,11 +545,12 @@
       <div class="collapse-content px-4 grid grid-cols-2 gap-x-2.5 gap-y-1">
 
         <fieldset class="fieldset col-span-2">
-          <legend class="fieldset-legend">Total energy consumption annually</legend>
-          <label class="input w-full">
-            <input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" />
+          <legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+          <label class="input w-full bg-[var(--bg--weak-50)]">
+            <input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span>
           </label>
+          <p class="label-text-alt text-[var(--text--soft-400)]">Total power (kW) × hrs/day × days/wk × wks/yr × sensor factor</p>
         </fieldset>
 
         <fieldset class="fieldset">
@@ -591,18 +603,20 @@
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total lighting power<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input w-full">
-        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" onchange="recalcLightingLPD()" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="total_lighting_power" placeholder="Auto-calculated" min="0" step="0.0001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Fixtures × Wattage ÷ 1000</p>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline Lighting Power Density (LPD)</legend>
-      <label class="input w-full">
-        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" />
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="baseline_lpd" placeholder="Auto-calculated" min="0" step="0.000001" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW/m²</span>
       </label>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Total lighting power ÷ Area of room</p>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
@@ -610,19 +624,19 @@
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" />
+            <input type="number" placeholder="e.g. 10" name="operating_hours_per_day" required min="1" max="24" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">hrs / day</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" />
+            <input type="number" placeholder="e.g. 5" name="operating_days_per_week" required min="1" max="7" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
           </label>
         </div>
         <div class="flex-1">
           <label class="input validator w-full">
-            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" />
+            <input type="number" placeholder="e.g. 50" name="operating_weeks_per_year" required min="1" max="52" oninput="recalcLightingEnergy()" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
           </label>
         </div>
@@ -638,11 +652,12 @@
       <div class="collapse-content px-4 grid grid-cols-2 gap-x-2.5 gap-y-1">
 
         <fieldset class="fieldset col-span-2">
-          <legend class="fieldset-legend">Total energy consumption annually</legend>
-          <label class="input w-full">
-            <input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" />
+          <legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+          <label class="input w-full bg-[var(--bg--weak-50)]">
+            <input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" />
             <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span>
           </label>
+          <p class="label-text-alt text-[var(--text--soft-400)]">Total power (kW) × hrs/day × days/wk × wks/yr</p>
         </fieldset>
 
         <fieldset class="fieldset">
@@ -726,6 +741,8 @@
     if (roomTypeSelect && roomTypeSelect.value) {
       applyLightingScheduleDefaults(roomTypeSelect.value);
     }
+    // Trigger energy recalc in case values were pre-populated (e.g. edit mode)
+    recalcLightingPower();
   };
 
   // ================================================================
@@ -773,6 +790,7 @@
       var totalKw = (fixtures * tubes * wattage) / 1000;
       powerEl.value = totalKw.toFixed(4);
       recalcLightingLPD();
+      recalcLightingEnergy();
     }
   };
 
@@ -795,6 +813,40 @@
     if (!isNaN(power) && !isNaN(area) && area > 0) {
       lpdEl.value = (power / area).toFixed(6);
     }
+    recalcLightingEnergy();
+  };
+
+  // ================================================================
+  // Auto-calculate annual energy
+  // Formula: Total_Lighting_Power × hrs/day × days/wk × wks/yr × sensor_factor
+  // sensor_factor = 0.80 if sensors = yes, else 1.00
+  // ================================================================
+  window.recalcLightingEnergy = function() {
+    var form = document.getElementById('lighting-system-form');
+    if (!form) return;
+
+    var powerEl  = form.querySelector('[name="total_lighting_power"]');
+    var hrsEl    = form.querySelector('[name="operating_hours_per_day"]');
+    var daysEl   = form.querySelector('[name="operating_days_per_week"]');
+    var weeksEl  = form.querySelector('[name="operating_weeks_per_year"]');
+    var energyEl = form.querySelector('[name="annual_energy_consumption"]');
+
+    if (!powerEl || !energyEl) return;
+
+    var power = parseFloat(powerEl.value);
+    var hrs   = hrsEl   ? parseFloat(hrsEl.value)   : NaN;
+    var days  = daysEl  ? parseFloat(daysEl.value)  : NaN;
+    var weeks = weeksEl ? parseFloat(weeksEl.value) : NaN;
+
+    if (isNaN(power) || isNaN(hrs) || isNaN(days) || isNaN(weeks)) {
+      energyEl.value = '';
+      return;
+    }
+
+    var sensorEl = form.querySelector('[name="installation_of_sensors"]:checked');
+    var sensorFactor = (sensorEl && sensorEl.value === 'yes') ? 0.80 : 1.00;
+
+    energyEl.value = (power * hrs * days * weeks * sensorFactor).toFixed(2);
   };
 
   // ================================================================
@@ -1010,9 +1062,10 @@
       setLightingField(form, 'operating_days_per_week', system.workdays_per_week);
       setLightingField(form, 'operating_weeks_per_year', system.workweeks_per_year);
       setLightingRadio(form, 'installation_of_sensors', system.sensors_installed ? 'yes' : 'no');
-      setLightingField(form, 'annual_energy_consumption', system.total_energy_consumption_kwh_per_year);
       setLightingField(form, 'energy_efficiency_label', system.energy_efficiency_label);
       setLightingField(form, 'number_of_stars', system.number_of_stars);
+      // Recompute auto-calculated fields with the loaded values
+      recalcLightingPower();
 
       lighting_system_modal.showModal();
     } catch (error) {

--- a/templates/pages/add-building/components/operational-details/ventilation-system.html
+++ b/templates/pages/add-building/components/operational-details/ventilation-system.html
@@ -77,7 +77,7 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total number of units installed<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="number_of_units" placeholder="e.g. 3" required min="1" />
+        <input type="number" name="number_of_units" placeholder="e.g. 3" required min="1" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
       </label>
       <p class="validator-hint">Must be at least 1</p>
     </fieldset>
@@ -85,7 +85,7 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline efficiency<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="baseline_efficiency" placeholder="0.30 – 1.20" required min="0.01" max="10" step="0.01" />
+        <input type="number" name="baseline_efficiency" placeholder="0.30 – 1.20" required min="0.01" max="10" step="0.01" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">W/CMH</span>
       </label>
       <p class="validator-hint">Typical: 0.30 – 1.20 W/CMH</p>
@@ -94,16 +94,16 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Installation of Variable Speed Drives (VSD)<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="yes" class="radio radio-xs" onchange="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="no" class="radio radio-xs" checked onchange="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" /> No</label>
       </div>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Installation of Demand Controlled Ventilation (DCV)<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="yes" class="radio radio-xs" onchange="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="no" class="radio radio-xs" checked onchange="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" /> No</label>
       </div>
     </fieldset>
 
@@ -113,27 +113,27 @@
       </legend>
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_hours_per_day" id="ahu-hours" placeholder="e.g. 10" required min="1" max="24" />
+          <input type="number" name="operating_hours_per_day" id="ahu-hours" placeholder="e.g. 10" required min="1" max="24" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">Hours / day</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_days_per_week" id="ahu-days" placeholder="e.g. 5" required min="1" max="7" />
+          <input type="number" name="operating_days_per_week" id="ahu-days" placeholder="e.g. 5" required min="1" max="7" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_weeks_per_year" id="ahu-weeks" placeholder="e.g. 52" required min="1" max="52" />
+          <input type="number" name="operating_weeks_per_year" id="ahu-weeks" placeholder="e.g. 52" required min="1" max="52" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
         </label></div>
       </div>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
-      <legend class="fieldset-legend">Total ventilation system power input<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input validator w-full">
-        <input type="number" name="power_input" placeholder="e.g. 15" required min="0" step="0.01" />
+      <legend class="fieldset-legend">Total ventilation system power input</legend>
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="power_input" placeholder="Auto-calculated" min="0" step="0.01" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
-      <p class="validator-hint">This field is required</p>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Airflow (CMH) × Baseline efficiency (W/CMH) × Units ÷ 1000</p>
     </fieldset>
 
     <div class="col-span-2 mt-3">
@@ -146,14 +146,15 @@
           <div class="grid grid-cols-2 gap-2">
             <fieldset class="fieldset"><legend class="fieldset-legend">Air flow rate <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
               <label class="input w-full pr-0 overflow-hidden">
-                <input type="number" name="airflow_rate" placeholder="e.g. 5000" min="0" />
+                <input type="number" name="airflow_rate" placeholder="e.g. 5000" min="0" oninput="recalcVentPowerAndEnergy(this.closest('form'),'ahu')" />
                 <select class="select select-ghost focus:!outline-none !pr-0 rounded-none w-25" name="ventilation_capacity">
                   <option value="M3H" selected>CMH</option><option value="F3M">CFM</option>
                 </select>
               </label>
             </fieldset>
-            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
-              <label class="input w-full"><input type="number" name="annual_energy_consumption" placeholder="e.g. 30000" min="0" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+              <label class="input w-full bg-[var(--bg--weak-50)]"><input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+              <p class="label-text-alt text-[var(--text--soft-400)]">Power (kW) × hrs/day × days/wk × wks/yr × VSD factor × DCV factor</p>
             </fieldset>
           </div>
         </div>
@@ -189,15 +190,15 @@
       </legend>
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_hours_per_day" id="fcu-hours" placeholder="e.g. 10" required min="1" max="24" />
+          <input type="number" name="operating_hours_per_day" id="fcu-hours" placeholder="e.g. 10" required min="1" max="24" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">Hours / day</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_days_per_week" id="fcu-days" placeholder="e.g. 5" required min="1" max="7" />
+          <input type="number" name="operating_days_per_week" id="fcu-days" placeholder="e.g. 5" required min="1" max="7" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_weeks_per_year" id="fcu-weeks" placeholder="e.g. 52" required min="1" max="52" />
+          <input type="number" name="operating_weeks_per_year" id="fcu-weeks" placeholder="e.g. 52" required min="1" max="52" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
         </label></div>
       </div>
@@ -206,7 +207,7 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Total ventilation system power input<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="power_input" placeholder="e.g. 8" required min="0" step="0.01" />
+        <input type="number" name="power_input" placeholder="e.g. 8" required min="0" step="0.01" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
       <p class="validator-hint">This field is required</p>
@@ -228,8 +229,9 @@
                 </select>
               </label>
             </fieldset>
-            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
-              <label class="input w-full"><input type="number" name="annual_energy_consumption" placeholder="e.g. 15000" min="0" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+              <label class="input w-full bg-[var(--bg--weak-50)]"><input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+              <p class="label-text-alt text-[var(--text--soft-400)]">Power (kW) × hrs/day × days/wk × wks/yr</p>
             </fieldset>
           </div>
         </div>
@@ -245,7 +247,7 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Total number of units installed<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="number_of_units" placeholder="e.g. 2" required min="1" />
+        <input type="number" name="number_of_units" placeholder="e.g. 2" required min="1" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
       </label>
       <p class="validator-hint">Must be at least 1</p>
     </fieldset>
@@ -253,7 +255,7 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Baseline efficiency<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="baseline_efficiency" placeholder="0.30 – 1.20" required min="0.01" max="10" step="0.01" />
+        <input type="number" name="baseline_efficiency" placeholder="0.30 – 1.20" required min="0.01" max="10" step="0.01" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">W/CMH</span>
       </label>
       <p class="validator-hint">Typical: 0.30 – 1.20 W/CMH</p>
@@ -262,16 +264,16 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Installation of Variable Speed Drives (VSD)<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="yes" class="radio radio-xs" onchange="recalcVentPowerAndEnergy(this.closest('form'),'doas')" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="variable_speed_drives" value="no" class="radio radio-xs" checked onchange="recalcVentPowerAndEnergy(this.closest('form'),'doas')" /> No</label>
       </div>
     </fieldset>
 
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Installation of Demand Controlled Ventilation (DCV)<span class="text-[var(--state--error--base)]">*</span></legend>
       <div class="flex items-center gap-2.5 mt-1">
-        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="yes" class="radio radio-xs" /> Yes</label>
-        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="no" class="radio radio-xs" checked /> No</label>
+        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="yes" class="radio radio-xs" onchange="recalcVentPowerAndEnergy(this.closest('form'),'doas')" /> Yes</label>
+        <label class="flex items-center gap-2"><input type="radio" name="demand_controlled_ventilation" value="no" class="radio radio-xs" checked onchange="recalcVentPowerAndEnergy(this.closest('form'),'doas')" /> No</label>
       </div>
     </fieldset>
 
@@ -281,27 +283,27 @@
       </legend>
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_hours_per_day" id="doas-hours" placeholder="e.g. 12" required min="1" max="24" />
+          <input type="number" name="operating_hours_per_day" id="doas-hours" placeholder="e.g. 12" required min="1" max="24" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">Hours / day</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_days_per_week" id="doas-days" placeholder="e.g. 5" required min="1" max="7" />
+          <input type="number" name="operating_days_per_week" id="doas-days" placeholder="e.g. 5" required min="1" max="7" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_weeks_per_year" id="doas-weeks" placeholder="e.g. 52" required min="1" max="52" />
+          <input type="number" name="operating_weeks_per_year" id="doas-weeks" placeholder="e.g. 52" required min="1" max="52" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
         </label></div>
       </div>
     </fieldset>
 
     <fieldset class="fieldset col-span-2">
-      <legend class="fieldset-legend">Total ventilation system power input<span class="text-[var(--state--error--base)]">*</span></legend>
-      <label class="input validator w-full">
-        <input type="number" name="power_input" placeholder="e.g. 20" required min="0" step="0.01" />
+      <legend class="fieldset-legend">Total ventilation system power input</legend>
+      <label class="input w-full bg-[var(--bg--weak-50)]">
+        <input type="number" name="power_input" placeholder="Auto-calculated" min="0" step="0.01" readonly class="cursor-not-allowed" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
-      <p class="validator-hint">This field is required</p>
+      <p class="label-text-alt text-[var(--text--soft-400)]">Airflow (CMH) × Baseline efficiency (W/CMH) × Units ÷ 1000</p>
     </fieldset>
 
     <div class="col-span-2 mt-3">
@@ -314,14 +316,15 @@
           <div class="grid grid-cols-2 gap-2">
             <fieldset class="fieldset"><legend class="fieldset-legend">Air flow rate <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
               <label class="input w-full pr-0 overflow-hidden">
-                <input type="number" name="airflow_rate" placeholder="e.g. 8000" min="0" />
+                <input type="number" name="airflow_rate" placeholder="e.g. 8000" min="0" oninput="recalcVentPowerAndEnergy(this.closest('form'),'doas')" />
                 <select class="select select-ghost focus:!outline-none !pr-0 rounded-none w-25" name="ventilation_capacity">
                   <option value="M3H" selected>CMH</option><option value="F3M">CFM</option>
                 </select>
               </label>
             </fieldset>
-            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
-              <label class="input w-full"><input type="number" name="annual_energy_consumption" placeholder="e.g. 40000" min="0" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+              <label class="input w-full bg-[var(--bg--weak-50)]"><input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+              <p class="label-text-alt text-[var(--text--soft-400)]">Power (kW) × hrs/day × days/wk × wks/yr × VSD factor × DCV factor</p>
             </fieldset>
           </div>
         </div>
@@ -366,15 +369,15 @@
       </legend>
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_hours_per_day" id="cassette-hours" placeholder="e.g. 10" required min="1" max="24" />
+          <input type="number" name="operating_hours_per_day" id="cassette-hours" placeholder="e.g. 10" required min="1" max="24" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">Hours / day</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_days_per_week" id="cassette-days" placeholder="e.g. 5" required min="1" max="7" />
+          <input type="number" name="operating_days_per_week" id="cassette-days" placeholder="e.g. 5" required min="1" max="7" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_weeks_per_year" id="cassette-weeks" placeholder="e.g. 52" required min="1" max="52" />
+          <input type="number" name="operating_weeks_per_year" id="cassette-weeks" placeholder="e.g. 52" required min="1" max="52" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
         </label></div>
       </div>
@@ -383,7 +386,7 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Total ventilation system power input<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="power_input" placeholder="e.g. 12" required min="0" step="0.01" />
+        <input type="number" name="power_input" placeholder="e.g. 12" required min="0" step="0.01" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
       <p class="validator-hint">This field is required</p>
@@ -405,8 +408,9 @@
                 </select>
               </label>
             </fieldset>
-            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
-              <label class="input w-full"><input type="number" name="annual_energy_consumption" placeholder="e.g. 20000" min="0" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+              <label class="input w-full bg-[var(--bg--weak-50)]"><input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+              <p class="label-text-alt text-[var(--text--soft-400)]">Power (kW) × hrs/day × days/wk × wks/yr</p>
             </fieldset>
           </div>
         </div>
@@ -442,15 +446,15 @@
       </legend>
       <div class="w-full flex gap-1.5 items-center">
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_hours_per_day" id="fan-hours" placeholder="e.g. 12" required min="1" max="24" />
+          <input type="number" name="operating_hours_per_day" id="fan-hours" placeholder="e.g. 12" required min="1" max="24" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">Hours / day</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_days_per_week" id="fan-days" placeholder="e.g. 7" required min="1" max="7" />
+          <input type="number" name="operating_days_per_week" id="fan-days" placeholder="e.g. 7" required min="1" max="7" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">days / week</span>
         </label></div>
         <div class="flex-1"><label class="input validator w-full">
-          <input type="number" name="operating_weeks_per_year" id="fan-weeks" placeholder="e.g. 52" required min="1" max="52" />
+          <input type="number" name="operating_weeks_per_year" id="fan-weeks" placeholder="e.g. 52" required min="1" max="52" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
           <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">weeks / year</span>
         </label></div>
       </div>
@@ -459,7 +463,7 @@
     <fieldset class="fieldset col-span-2">
       <legend class="fieldset-legend">Total ventilation system power input<span class="text-[var(--state--error--base)]">*</span></legend>
       <label class="input validator w-full">
-        <input type="number" name="power_input" placeholder="e.g. 2" required min="0" step="0.01" />
+        <input type="number" name="power_input" placeholder="e.g. 2" required min="0" step="0.01" oninput="recalcVentSimpleEnergy(this.closest('form'))" />
         <span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kW</span>
       </label>
       <p class="validator-hint">This field is required</p>
@@ -488,8 +492,9 @@
                 <option value="4">4</option><option value="5">5</option>
               </select>
             </fieldset>
-            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Optional)</span></legend>
-              <label class="input w-full"><input type="number" name="annual_energy_consumption" placeholder="e.g. 5000" min="0" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+            <fieldset class="fieldset col-span-2"><legend class="fieldset-legend">Total energy consumption annually <span class="text-[var(--text--sub-600)]">(Auto-calculated)</span></legend>
+              <label class="input w-full bg-[var(--bg--weak-50)]"><input type="number" name="annual_energy_consumption" placeholder="Auto-calculated" min="0" readonly class="cursor-not-allowed" /><span class="text-sm/5 align-middle text-[var(--text--sub-600)]">kWh/year</span></label>
+              <p class="label-text-alt text-[var(--text--soft-400)]">Power (kW) × hrs/day × days/wk × wks/yr</p>
             </fieldset>
           </div>
         </div>
@@ -499,6 +504,75 @@
 </template>
 
 <script>
+  // ================================================================
+  // Auto-calculation helpers for ventilation systems
+  // ================================================================
+
+  // AHU / DOAS: power_input = airflow × baseline_efficiency × units ÷ 1000
+  //             annual_energy = power_input × h × d × w × VSD_factor × DCV_factor
+  window.recalcVentPowerAndEnergy = function(form, ventType) {
+    if (!form) return;
+    var airflowEl   = form.querySelector('[name="airflow_rate"]');
+    var effEl       = form.querySelector('[name="baseline_efficiency"]');
+    var unitsEl     = form.querySelector('[name="number_of_units"]');
+    var powerEl     = form.querySelector('[name="power_input"]');
+    var energyEl    = form.querySelector('[name="annual_energy_consumption"]');
+
+    var airflow  = airflowEl  ? parseFloat(airflowEl.value)  : NaN;
+    var eff      = effEl      ? parseFloat(effEl.value)      : NaN;
+    var units    = unitsEl    ? parseFloat(unitsEl.value)    : NaN;
+
+    // Recalculate power_input from airflow when all three inputs are present
+    if (!isNaN(airflow) && !isNaN(eff) && !isNaN(units) && airflow > 0 && units > 0) {
+      if (powerEl) powerEl.value = ((airflow * eff * units) / 1000).toFixed(4);
+    }
+
+    // Recalculate annual energy
+    if (!energyEl || !powerEl) return;
+    var power = parseFloat(powerEl.value);
+    var hrsEl   = form.querySelector('[name="operating_hours_per_day"]');
+    var daysEl  = form.querySelector('[name="operating_days_per_week"]');
+    var weeksEl = form.querySelector('[name="operating_weeks_per_year"]');
+    var hrs   = hrsEl   ? parseFloat(hrsEl.value)   : NaN;
+    var days  = daysEl  ? parseFloat(daysEl.value)  : NaN;
+    var weeks = weeksEl ? parseFloat(weeksEl.value) : NaN;
+
+    if (isNaN(power) || isNaN(hrs) || isNaN(days) || isNaN(weeks)) {
+      energyEl.value = '';
+      return;
+    }
+
+    // VSD factor (AHU/DOAS only)
+    var vsdEl = form.querySelector('[name="variable_speed_drives"]:checked');
+    var dcvEl = form.querySelector('[name="demand_controlled_ventilation"]:checked');
+    var vsdFactor = (vsdEl && vsdEl.value === 'yes') ? 0.80 : 1.00;
+    var dcvFactor = (dcvEl && dcvEl.value === 'yes') ? 0.70 : 1.00;
+
+    energyEl.value = (power * hrs * days * weeks * vsdFactor * dcvFactor).toFixed(2);
+  };
+
+  // FCU / Cassette / Fan: annual_energy = power_input × h × d × w
+  window.recalcVentSimpleEnergy = function(form) {
+    if (!form) return;
+    var powerEl  = form.querySelector('[name="power_input"]');
+    var energyEl = form.querySelector('[name="annual_energy_consumption"]');
+    if (!powerEl || !energyEl) return;
+
+    var power = parseFloat(powerEl.value);
+    var hrsEl   = form.querySelector('[name="operating_hours_per_day"]');
+    var daysEl  = form.querySelector('[name="operating_days_per_week"]');
+    var weeksEl = form.querySelector('[name="operating_weeks_per_year"]');
+    var hrs   = hrsEl   ? parseFloat(hrsEl.value)   : NaN;
+    var days  = daysEl  ? parseFloat(daysEl.value)  : NaN;
+    var weeks = weeksEl ? parseFloat(weeksEl.value) : NaN;
+
+    if (isNaN(power) || isNaN(hrs) || isNaN(days) || isNaN(weeks)) {
+      energyEl.value = '';
+      return;
+    }
+    energyEl.value = (power * hrs * days * weeks).toFixed(2);
+  };
+
   var VENT_CLIMATE_ZONE = "{{ climate_zone }}";
 
   if (!window.editingVentilationSystemId) window.editingVentilationSystemId = null;
@@ -714,6 +788,13 @@
         sf('number_of_stars', system.number_of_stars);
         sr('variable_speed_drives', system.variable_speed_drives ? 'yes' : 'no');
         sr('demand_controlled_ventilation', system.demand_controlled_ventilation ? 'yes' : 'no');
+
+        // Recompute auto-calculated fields with loaded values
+        if (system.ventilation_type === 'AHU' || system.ventilation_type === 'DOAS') {
+          recalcVentPowerAndEnergy(form, system.ventilation_type.toLowerCase());
+        } else {
+          recalcVentSimpleEnergy(form);
+        }
       }, 200);
 
       ventilation_system_modal.showModal();


### PR DESCRIPTION
## Summary

  - **Ventilation**: `power_input` on AHU and DOAS is now auto-calculated (`Airflow × Baseline efficiency × Units ÷ 1000`) and readonly.
  `annual_energy_consumption` is now auto-calculated (`Power × schedule × VSD factor × DCV factor`) and readonly across all five ventilation types (AHU, DOAS,   
  FCU, Cassette AC, Fan).
  - **Lighting**: `total_lighting_power` and `baseline_lpd` were already JS-computed but remained editable — both are now readonly. `annual_energy_consumption`  
  is now auto-calculated (`Total power × schedule × sensor factor`) and readonly across all five lighting templates (LED, Fluorescent, CFL, Incandescent/Halogen,
   HID).
  - Hot water and lift/escalator systems were already correct and left unchanged.

  ## Formulas verified against spec

  | System | Field | Formula |
  |---|---|---|
  | AHU / DOAS | `power_input` | `Airflow (CMH) × Efficiency (W/CMH) × Units ÷ 1000` |
  | AHU / DOAS | `annual_energy_consumption` | `Power × h/d × d/w × w/y × VSD factor × DCV factor` |
  | FCU / Cassette / Fan | `annual_energy_consumption` | `Power × h/d × d/w × w/y` |
  | All lighting types | `total_lighting_power` | `Fixtures × (Tubes ×) Wattage ÷ 1000` |
  | All lighting types | `baseline_lpd` | `Total lighting power ÷ Area of room` |
  | All lighting types | `annual_energy_consumption` | `Total power × h/d × d/w × w/y × sensor factor` |

 