### PR TITLE
  fix: allow decimal refrigerant quantities and fix BoQ legend asterisk

### DIFF
--- a/pages/migrations/0029_refrigerant_quantity_decimal.py
+++ b/pages/migrations/0029_refrigerant_quantity_decimal.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0028_add_ac_capacity_eer_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coolingsystemchiller',
+            name='refrigerant_quantity_kg',
+            field=models.DecimalField(decimal_places=2, max_digits=8, verbose_name='Refrigerant Quantity (Kg)'),
+        ),
+        migrations.AlterField(
+            model_name='coolingsystemairconditioner',
+            name='refrigerant_quantity_kg',
+            field=models.DecimalField(decimal_places=2, max_digits=8, verbose_name='Refrigerant Quantity (Kg)'),
+        ),
+    ]

--- a/pages/models/building_operation/air_conditioning.py
+++ b/pages/models/building_operation/air_conditioning.py
@@ -53,7 +53,8 @@ class CoolingSystemAirConditioner(models.Model):
         choices=RefrigerantType.choices,
         verbose_name=_("Type of Refrigerants"),
     )
-    refrigerant_quantity_kg = models.PositiveIntegerField(
+    refrigerant_quantity_kg = models.DecimalField(
+        max_digits=8, decimal_places=2,
         verbose_name=_("Refrigerant Quantity (Kg)")
     )
     total_cooling_load_rt = models.PositiveIntegerField(

--- a/pages/models/building_operation/chilling.py
+++ b/pages/models/building_operation/chilling.py
@@ -162,7 +162,8 @@ class CoolingSystemChiller(models.Model):
         choices=RefrigerantType.choices,
         verbose_name=_("Type of Refrigerants"),
     )
-    refrigerant_quantity_kg = models.PositiveIntegerField(
+    refrigerant_quantity_kg = models.DecimalField(
+        max_digits=8, decimal_places=2,
         verbose_name=_("Refrigerant Quantity (Kg)")
     )
     total_cooling_load_rt = models.PositiveIntegerField(

--- a/templates/pages/add-building/components/building-information/building-details.html
+++ b/templates/pages/add-building/components/building-information/building-details.html
@@ -163,7 +163,7 @@
   <!-- BoQ / Design Drawings -->
   <fieldset class="fieldset col-span-2">
     <legend class="fieldset-legend">
-      Does the building have design drawings and Bill of Quantities (BoQ), would you like to upload it?<span class="text-[var(--state--error--base)]">*</span>
+      Does the building have design drawings and Bill of Quantities (BoQ) that you can upload?<span class="text-[var(--state--error--base)]">*</span>
     </legend>
     <div class="flex items-center gap-2.5">
       <label class="flex items-center gap-2">


### PR DESCRIPTION
Pull request:

  Summary

  - refrigerant_quantity_kg on both CoolingSystemChiller and CoolingSystemAirConditioner was a PositiveIntegerField, which rejected decimal values like 1.4;     
  changed to DecimalField(max_digits=8, decimal_places=2) with migration 0029
  - Reworded the BoQ/design drawings legend in the building details step so the mandatory asterisk no longer wraps onto its own line

  Test plan

  - Add a chiller or AC system with a decimal refrigerant quantity (e.g. 12.5) and verify it saves and displays correctly
  - Verify existing integer quantities still save without issue
  - Check building details step — confirm the asterisk appears immediately after the BoQ question text on the same line
  - Run pytest pages/tests/test_cooling_system.py
