### PR TITLE
fix: delete cert/BoQ files from storage on building delete and fix import step-upload 500 error

### DIFF
--- a/pages/views/building/import_building.py
+++ b/pages/views/building/import_building.py
@@ -6,6 +6,7 @@ from decimal import Decimal, InvalidOperation
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import render
+from django.templatetags.static import static
 from django.views.decorators.http import require_http_methods
 
 from accounts.models import CustomCity, CustomRegion
@@ -2506,6 +2507,15 @@ def cancel_import(request):
     try:
         uuid_obj = uuid_lib.UUID(building_uuid_str)
         building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
+
+        # Delete certification file from storage
+        if building.certification_file:
+            building.certification_file.delete(save=False)
+
+        # Delete all BoQ files from storage
+        for boq in building.boq_files.all():
+            boq.file.delete(save=False)
+
         building.delete()
         logger.info(f"Import cancelled: building {building_uuid_str} deleted by {request.user}")
     except (ValueError, Building.DoesNotExist):
@@ -2528,7 +2538,13 @@ def view_initial_import_dialog(request):
 
 def view_import_building_step(request, step_id):
     logger.debug(f"Received request for import building step: {step_id}")
-    return render(request, f"pages/home/import-dialog/{step_id}.html")
+    context = {}
+    if step_id == "step-upload":
+        try:
+            context["import_template_url"] = static("docs/import-template.xlsx")
+        except Exception:
+            context["import_template_url"] = None
+    return render(request, f"pages/home/import-dialog/{step_id}.html", context)
 
 
 # ---------------------------------------------------------------------------

--- a/pages/views/home.py
+++ b/pages/views/home.py
@@ -126,5 +126,12 @@ def _delete_building(building_id):
     
     
     building_to_delete = get_object_or_404(Building, id=building_id)
+
+    # Delete certification file and BoQ files from storage before deleting the building
+    if building_to_delete.certification_file:
+        building_to_delete.certification_file.delete(save=False)
+    for boq in building_to_delete.boq_files.all():
+        boq.file.delete(save=False)
+
     building_to_delete.delete()
     logger.info("Successfully deleted building '%s' from list", building_to_delete)

--- a/templates/pages/home/import-dialog/step-upload.html
+++ b/templates/pages/home/import-dialog/step-upload.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div class="flex-1 size-full flex flex-col items-center justify-center gap-4 py-5">
   <div class="sapce-y-0.5 text-center max-w-70 text-[var(--text--strong-950)]">
     <h6 class="h6-title">Upload Your Data File</h6>
@@ -11,12 +10,14 @@
     <!-- Component injected by JS -->
   </div>
 
+  {% if import_template_url %}
   <p class="paragraph-small text-[var(--text--strong-950)]">
     Need a template?
-    <a href="{% static 'docs/import-template.xlsx' %}" download class="text-[var(--state--information--base)] underline cursor-pointer">
+    <a href="{{ import_template_url }}" download class="text-[var(--state--information--base)] underline cursor-pointer">
       Download sample template
     </a>
   </p>
+  {% endif %}
 </div>
 
 <!-- State 1: No File Selected -->


### PR DESCRIPTION
## Summary

  - Fix 500 error on /import-dialog/step/step-upload/ in production: CompressedManifestStaticFilesStorage (Whitenoise) raises ValueError when the static manifest
   doesn't exist, crashing the import dialog on the upload step. Moved static URL resolution to the view with a safe try/except fallback.
  - Fix building deletion not cleaning up uploaded files: deleting a building from the home list now also deletes its certification file and BoQ files from      
  storage, consistent with cancel-import behaviour.