### PR TITLE
feat: BEAT admin tool REST API — buildings module   

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -12,6 +12,37 @@ from api.views.organisation import (
     OrganisationDetailView,
     OrganisationBuildingsView,
 )
+from api.views.buildings import (
+    BuildingListView,
+    BuildingDetailView,
+    BuildingImportNameLocationView,
+    BuildingImportDetailsView,
+    BuildingImportOperationalScheduleView,
+    BuildingImportCoolingSystemsView,
+    BuildingImportVentilationSystemsView,
+    BuildingImportLightingSystemsView,
+    BuildingImportLiftEscalatorView,
+    BuildingImportHotWaterSystemsView,
+    BuildingImportEnergyCarriersView,
+    BuildingImportStructuralComponentsView,
+    BuildingCompleteView,
+)
+from api.views.building_add import (
+    BuildingAddNameLocationView,
+    BuildingAddDetailsView,
+    BuildingAddDataView,
+    BuildingAddOperationalScheduleView,
+    BuildingAddCoolingSystemView,
+    BuildingAddVentilationSystemView,
+    BuildingAddLightingSystemView,
+    BuildingAddLiftEscalatorView,
+    BuildingAddHotWaterSystemView,
+    BuildingAddEnergyCarriersView,
+    BuildingAddStructuralComponentView,
+    BuildingAddCompleteView,
+)
+from api.views.building_detail import BuildingFullDetailView
+from api.views.building_export import BuildingExportView
 from api.views.users import (
     UserListCreateView,
     UserDetailView,
@@ -40,6 +71,41 @@ urlpatterns = [
     path("auth/token/refresh/", AdminTokenRefreshView.as_view(), name="api_token_refresh"),
     path("auth/forgot-password/", AdminForgotPasswordView.as_view(), name="api_admin_forgot_password"),
     path("auth/profile/", AdminProfileView.as_view(), name="api_admin_profile"),
+
+    # Buildings — list & export
+    path("buildings/", BuildingListView.as_view(), name="api_buildings"),
+    path("buildings/export/", BuildingExportView.as_view(), name="api_buildings_export"),
+
+    # Buildings — detail & full-detail
+    path("buildings/<uuid:pk>/", BuildingDetailView.as_view(), name="api_building_detail"),
+    path("buildings/<uuid:pk>/detail/", BuildingFullDetailView.as_view(), name="api_building_full_detail"),
+
+    # Buildings — Excel import (step-by-step)
+    path("buildings/import/name-location/", BuildingImportNameLocationView.as_view(), name="api_building_import_name_location"),
+    path("buildings/import/details/", BuildingImportDetailsView.as_view(), name="api_building_import_details"),
+    path("buildings/import/operational-schedule/", BuildingImportOperationalScheduleView.as_view(), name="api_building_import_operational_schedule"),
+    path("buildings/import/cooling-systems/", BuildingImportCoolingSystemsView.as_view(), name="api_building_import_cooling_systems"),
+    path("buildings/import/ventilation-systems/", BuildingImportVentilationSystemsView.as_view(), name="api_building_import_ventilation_systems"),
+    path("buildings/import/lighting-systems/", BuildingImportLightingSystemsView.as_view(), name="api_building_import_lighting_systems"),
+    path("buildings/import/lift-escalator/", BuildingImportLiftEscalatorView.as_view(), name="api_building_import_lift_escalator"),
+    path("buildings/import/hot-water-systems/", BuildingImportHotWaterSystemsView.as_view(), name="api_building_import_hot_water_systems"),
+    path("buildings/import/energy-carriers/", BuildingImportEnergyCarriersView.as_view(), name="api_building_import_energy_carriers"),
+    path("buildings/import/structural-components/", BuildingImportStructuralComponentsView.as_view(), name="api_building_import_structural_components"),
+    path("buildings/import/complete/", BuildingCompleteView.as_view(), name="api_building_import_complete"),
+
+    # Buildings — manual add (multi-step form)
+    path("buildings/add/name-location/", BuildingAddNameLocationView.as_view(), name="api_building_add_name_location"),
+    path("buildings/add/details/", BuildingAddDetailsView.as_view(), name="api_building_add_details"),
+    path("buildings/add/data/", BuildingAddDataView.as_view(), name="api_building_add_data"),
+    path("buildings/add/operational-schedule/", BuildingAddOperationalScheduleView.as_view(), name="api_building_add_operational_schedule"),
+    path("buildings/add/cooling-systems/", BuildingAddCoolingSystemView.as_view(), name="api_building_add_cooling_systems"),
+    path("buildings/add/ventilation-systems/", BuildingAddVentilationSystemView.as_view(), name="api_building_add_ventilation_systems"),
+    path("buildings/add/lighting-systems/", BuildingAddLightingSystemView.as_view(), name="api_building_add_lighting_systems"),
+    path("buildings/add/lift-escalator/", BuildingAddLiftEscalatorView.as_view(), name="api_building_add_lift_escalator"),
+    path("buildings/add/hot-water-systems/", BuildingAddHotWaterSystemView.as_view(), name="api_building_add_hot_water_systems"),
+    path("buildings/add/energy-carriers/", BuildingAddEnergyCarriersView.as_view(), name="api_building_add_energy_carriers"),
+    path("buildings/add/structural-components/", BuildingAddStructuralComponentView.as_view(), name="api_building_add_structural_components"),
+    path("buildings/add/complete/", BuildingAddCompleteView.as_view(), name="api_building_add_complete"),
 
     # Organisations
     path("organisations/", OrganisationListCreateView.as_view(), name="api_organisations"),

--- a/api/urls.py
+++ b/api/urls.py
@@ -52,6 +52,8 @@ from api.views.users import (
 from api.views.system_settings import (
     CountryListCreateView,
     CountryDetailView,
+    CountryRegionsView,
+    CountryCitiesView,
     CountryImportView,
     CountryExportView,
     ClimateTypeListCreateView,
@@ -123,6 +125,8 @@ urlpatterns = [
     path("system-settings/countries/import/", CountryImportView.as_view(), name="api_countries_import"),
     path("system-settings/countries/export/", CountryExportView.as_view(), name="api_countries_export"),
     path("system-settings/countries/<int:pk>/", CountryDetailView.as_view(), name="api_country_detail"),
+    path("system-settings/countries/<int:pk>/regions/", CountryRegionsView.as_view(), name="api_country_regions"),
+    path("system-settings/countries/<int:pk>/cities/", CountryCitiesView.as_view(), name="api_country_cities"),
 
     # System Settings — Climate Types
     path("system-settings/climate-types/", ClimateTypeListCreateView.as_view(), name="api_climate_types"),

--- a/api/views/building_add.py
+++ b/api/views/building_add.py
@@ -1,0 +1,990 @@
+"""
+API views for the add-building multi-step manual form.
+
+These mirror the HTMX add_building_steps / cooling_system / ventilation_system /
+lighting_system / lift_escalator_system / hot_water_system / building_step_operational
+views but:
+  - Require JWT admin authentication (IsAdminUser)
+  - Use _buildings_queryset() for org-scoped access instead of created_by=request.user
+  - Accept/return JSON exclusively
+  - Include organisation_id on step 1 so the building is org-linked from creation
+
+Step layout (matches the HTMX wizard):
+  POST /api/buildings/add/name-location/         Step 1 — create/update name & location
+  POST /api/buildings/add/details/               Step 2 — building type, climate, areas
+  GET  /api/buildings/add/data/                  Restore form data by UUID
+  POST /api/buildings/add/operational-schedule/  Step 3 — schedule & temperatures
+  POST /api/buildings/add/cooling-systems/       Step 4 — add/update/delete cooling
+  DELETE /api/buildings/add/cooling-systems/     Delete single cooling system
+  POST /api/buildings/add/ventilation-systems/   Step 5 — add/update/delete ventilation
+  DELETE /api/buildings/add/ventilation-systems/ Delete single ventilation system
+  POST /api/buildings/add/lighting-systems/      Step 6 — add/update/delete lighting
+  DELETE /api/buildings/add/lighting-systems/    Delete single lighting system
+  POST /api/buildings/add/lift-escalator/        Step 7 — create/update lift system
+  DELETE /api/buildings/add/lift-escalator/      Delete lift system
+  POST /api/buildings/add/hot-water-systems/     Step 8 — add/update/delete hot water
+  DELETE /api/buildings/add/hot-water-systems/   Delete single hot water system
+  POST /api/buildings/add/energy-carriers/       Step 9 — save operational products
+  POST /api/buildings/add/structural-components/ Step 10 — add assembly
+  DELETE /api/buildings/add/structural-components/ Delete single building assembly
+  POST /api/buildings/add/complete/              Mark building as published (draft=False)
+"""
+
+import logging
+import uuid as uuid_lib
+
+from django.db import transaction
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.permissions import IsAdminUser
+from api.views.buildings import _buildings_queryset, _get_building_or_error
+from pages.forms.cooling_system_form import CoolingSystemAirConditionerForm, CoolingSystemChillerForm
+from pages.forms.ventilation_system_form import VentilationSystemForm
+from pages.forms.lighting_system_form import LightingSystemForm
+from pages.forms.lift_escalator_system_form import LiftEscalatorSystemForm
+from pages.forms.hot_water_system_form import HotWaterSystemForm
+from pages.models.assembly import (
+    Assembly, AssemblyCategoryTechnique, AssemblyDimension, AssemblyMode,
+    AssemblyTechnique, StructuralProduct,
+)
+from pages.models.building import Building, BuildingAssembly, CategorySubcategory, OperationalProduct
+from pages.models.building_operation import (
+    CoolingSystemAirConditioner, CoolingSystemChiller,
+    LiftEscalatorSystem, HotWaterSystem,
+)
+from pages.models.building_operation.ventilation import VentilationSystem
+from pages.models.building_operation.lighting import LightingSystem
+from pages.models.epd import EPD
+from pages.models.organisation import Organisation
+from pages.views.building.import_building import (
+    _str,
+    _bool_from_excel,
+    _resolve_building_type,
+    _resolve_climate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Name & Location
+# ---------------------------------------------------------------------------
+
+class BuildingAddNameLocationView(APIView):
+    """
+    POST /api/buildings/add/name-location/
+
+    Creates a new building or updates an existing draft.
+    Pass organisation_id to link to an organisation.
+
+    Fields:
+      building_uuid   — omit to create, provide to update
+      building_name   — required
+      address         — required (→ street)
+      country         — country PK (integer)
+      region          — region PK (integer, optional)
+      city            — city PK (integer, optional)
+      longitude       — float, optional
+      latitude        — float, optional
+      organisation_id — UUID string, optional
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        errors = {}
+
+        building_name = _str(data.get("building_name"))
+        address = _str(data.get("address"))
+        country_id = data.get("country")
+        region_id = data.get("region") or None
+        city_id = data.get("city") or None
+        longitude = data.get("longitude") or None
+        latitude = data.get("latitude") or None
+        building_uuid_str = _str(data.get("building_uuid"))
+        organisation_id = _str(data.get("organisation_id"))
+
+        if not building_name:
+            errors["building_name"] = "Building name is required."
+        if not address:
+            errors["address"] = "Address is required."
+
+        try:
+            longitude = float(longitude) if longitude else None
+        except (ValueError, TypeError):
+            longitude = None
+        try:
+            latitude = float(latitude) if latitude else None
+        except (ValueError, TypeError):
+            latitude = None
+
+        # Resolve organisation
+        organisation = None
+        if organisation_id:
+            try:
+                org_qs = Organisation.objects.all()
+                if not request.user.is_superuser:
+                    org_qs = org_qs.filter(memberships__user=request.user)
+                organisation = org_qs.get(pk=organisation_id)
+            except Organisation.DoesNotExist:
+                errors["organisation_id"] = "Organisation not found or access denied."
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        if building_uuid_str:
+            try:
+                uuid_obj = uuid_lib.UUID(building_uuid_str)
+                building = _buildings_queryset(request).get(uuid=uuid_obj)
+                building.name = building_name
+                building.street = address
+                if country_id:
+                    building.country_id = country_id
+                building.region_id = region_id
+                building.city_id = city_id
+                building.longitude = longitude
+                building.latitude = latitude
+                if organisation:
+                    building.organisation = organisation
+                building.save()
+            except (ValueError, Building.DoesNotExist):
+                return Response(
+                    {"success": False, "errors": {"__all__": ["Building not found."]}},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+        else:
+            building = Building.objects.create(
+                name=building_name,
+                street=address,
+                country_id=country_id or None,
+                region_id=region_id,
+                city_id=city_id,
+                longitude=longitude,
+                latitude=latitude,
+                created_by=request.user,
+                organisation=organisation,
+                climate_zone=None,
+                total_floor_area=100,
+                reference_period=50,
+            )
+
+        logger.info("API Add Step 1: building %s saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Building Details
+# ---------------------------------------------------------------------------
+
+class BuildingAddDetailsView(APIView):
+    """
+    POST /api/buildings/add/details/
+
+    Updates building type, climate zone, floor area, construction year etc.
+
+    Fields:
+      building_uuid         — required
+      building_type_id      — BuildingCategory PK
+      apartment_type_id     — BuildingSubcategory PK
+      climate_type          — climate zone name or PK
+      assessment_period     — int (years)
+      total_floor_area      — float (m²)
+      conditioned_floor_area— float, optional
+      construction_year     — int, optional
+      floors_below_ground   — int, optional
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        errors = {}
+
+        # Building type → CategorySubcategory
+        building_type_id = data.get("building_type_id") or data.get("building_type")
+        apartment_type_id = data.get("apartment_type_id") or data.get("apartment_type")
+        cat_subcat = None
+        if building_type_id and apartment_type_id:
+            try:
+                cat_subcat = CategorySubcategory.objects.filter(
+                    category_id=building_type_id,
+                    subcategory_id=apartment_type_id,
+                ).first()
+            except Exception:
+                pass
+        elif building_type_id:
+            # Try string-based resolution as fallback
+            cat_subcat, bt_err = _resolve_building_type(_str(building_type_id))
+            if bt_err:
+                errors["building_type"] = bt_err
+
+        # Climate zone
+        climate_value = None
+        climate_raw = data.get("climate_type")
+        if climate_raw:
+            climate_value, climate_err = _resolve_climate(climate_raw)
+            if climate_err:
+                errors["climate_type"] = climate_err
+
+        # Assessment period
+        assessment_period = None
+        ap_raw = _str(data.get("assessment_period"))
+        if ap_raw:
+            try:
+                assessment_period = int(float(ap_raw))
+                if assessment_period <= 0:
+                    errors["assessment_period"] = "Assessment period must be positive."
+            except (ValueError, TypeError):
+                errors["assessment_period"] = "Assessment period must be a valid number."
+
+        # Total floor area
+        total_floor_area = None
+        tfa_raw = _str(data.get("total_floor_area"))
+        if tfa_raw:
+            try:
+                total_floor_area = float(tfa_raw)
+                if total_floor_area <= 0:
+                    errors["total_floor_area"] = "Total floor area must be greater than zero."
+            except (ValueError, TypeError):
+                errors["total_floor_area"] = "Total floor area must be a valid number."
+
+        # Optional fields
+        conditioned_floor_area = None
+        cfa_raw = _str(data.get("conditioned_floor_area"))
+        if cfa_raw:
+            try:
+                conditioned_floor_area = float(cfa_raw)
+            except (ValueError, TypeError):
+                errors["conditioned_floor_area"] = "Conditioned floor area must be a valid number."
+
+        construction_year = None
+        cy_raw = _str(data.get("construction_year"))
+        if cy_raw:
+            try:
+                construction_year = int(float(cy_raw))
+            except (ValueError, TypeError):
+                errors["construction_year"] = "Construction year must be a valid year."
+
+        floors_below_ground = None
+        fbg_raw = _str(data.get("floors_below_ground"))
+        if fbg_raw:
+            try:
+                floors_below_ground = int(float(fbg_raw))
+            except (ValueError, TypeError):
+                errors["floors_below_ground"] = "Floors below ground must be a valid number."
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        if cat_subcat:
+            building.category = cat_subcat
+        if climate_value is not None:
+            building.climate_zone = climate_value
+        if assessment_period is not None:
+            building.reference_period = assessment_period
+        if total_floor_area is not None:
+            building.total_floor_area = total_floor_area
+        if conditioned_floor_area is not None:
+            building.cond_floor_area = conditioned_floor_area
+        if construction_year is not None:
+            building.construction_year = construction_year
+        if floors_below_ground is not None:
+            building.floors_below_ground = floors_below_ground
+
+        building.save()
+
+        logger.info("API Add Step 2: building %s details saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+# ---------------------------------------------------------------------------
+# Restore form data (GET)
+# ---------------------------------------------------------------------------
+
+class BuildingAddDataView(APIView):
+    """
+    GET /api/buildings/add/data/?building_uuid=<uuid>
+
+    Returns building data formatted for form field restoration.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        building_uuid_str = request.query_params.get("building_uuid", "")
+        building, err = _get_building_or_error(request, building_uuid_str)
+        if err:
+            return err
+
+        building_type_id = None
+        apartment_type_id = None
+        if building.category:
+            building_type_id = building.category.category_id
+            apartment_type_id = building.category.subcategory_id
+
+        return Response({
+            "success": True,
+            "data": {
+                # Step 1
+                "building_name": building.name,
+                "address": building.street or "",
+                "country": building.country_id,
+                "region": building.region_id,
+                "city": building.city_id,
+                "longitude": building.longitude,
+                "latitude": building.latitude,
+                "organisation_id": str(building.organisation_id) if building.organisation_id else None,
+                # Step 2
+                "building_type_id": building_type_id,
+                "apartment_type_id": apartment_type_id,
+                "climate_type": building.climate_zone.name if building.climate_zone else "",
+                "assessment_period": building.reference_period,
+                "construction_year": building.construction_year,
+                "total_floor_area": str(building.total_floor_area) if building.total_floor_area else "",
+                "conditioned_floor_area": str(building.cond_floor_area) if building.cond_floor_area else "",
+                "floors_below_ground": building.floors_below_ground,
+                # Step 3
+                "num_residents": building.num_residents,
+                "hours_per_workday": building.hours_per_workday,
+                "workdays_per_week": building.workdays_per_week,
+                "weeks_per_year": building.weeks_per_year,
+                "heating_temp": float(building.heating_temp) if building.heating_temp else None,
+                "heating_temp_unit": building.heating_temp_unit,
+                "cooling_temp": float(building.cooling_temp) if building.cooling_temp else None,
+                "cooling_temp_unit": building.cooling_temp_unit,
+                "renewable_energy_percent": float(building.renewable_energy_percent) if building.renewable_energy_percent else None,
+                "building_smart_system": building.building_smart_system,
+            }
+        })
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Operational Schedule
+# ---------------------------------------------------------------------------
+
+class BuildingAddOperationalScheduleView(APIView):
+    """
+    POST /api/buildings/add/operational-schedule/
+
+    Fields: building_uuid, num_residents, hours_per_workday, workdays_per_week,
+            weeks_per_year, heating_temp, heating_temp_unit, cooling_temp,
+            cooling_temp_unit, renewable_energy_percent, building_smart_system
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        if data.get("num_residents") is not None:
+            building.num_residents = data.get("num_residents")
+        if data.get("hours_per_workday") is not None:
+            building.hours_per_workday = data.get("hours_per_workday")
+        if data.get("workdays_per_week") is not None:
+            building.workdays_per_week = data.get("workdays_per_week")
+        if data.get("weeks_per_year") is not None:
+            building.weeks_per_year = data.get("weeks_per_year")
+        if data.get("heating_temp") is not None:
+            building.heating_temp = data.get("heating_temp")
+        if data.get("heating_temp_unit"):
+            building.heating_temp_unit = data.get("heating_temp_unit")
+        if data.get("cooling_temp") is not None:
+            building.cooling_temp = data.get("cooling_temp")
+        if data.get("cooling_temp_unit"):
+            building.cooling_temp_unit = data.get("cooling_temp_unit")
+
+        renewable = data.get("renewable_energy_percent")
+        building.renewable_energy_percent = renewable if renewable not in (None, "", "0", 0) else None
+
+        smart_raw = data.get("building_smart_system", "no")
+        building.building_smart_system = _bool_from_excel(smart_raw) if isinstance(smart_raw, str) else bool(smart_raw)
+
+        building.save()
+
+        logger.info("API Add Step 3: building %s schedule saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — Cooling Systems (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddCoolingSystemView(APIView):
+    """
+    POST /api/buildings/add/cooling-systems/
+      Create or update a single cooling system.
+      cooling_system_type: "chiller" | "air_conditioner"
+      cooling_system_id: int (omit to create)
+
+    DELETE /api/buildings/add/cooling-systems/
+      cooling_system_id: int (required)
+      cooling_system_type: "chiller" | "air_conditioner"
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        ctype = data.get("cooling_system_type")
+        system_id = data.get("cooling_system_id")
+        is_update = bool(system_id)
+
+        if ctype == "chiller":
+            if is_update:
+                try:
+                    instance = CoolingSystemChiller.objects.get(id=system_id, building=building)
+                except CoolingSystemChiller.DoesNotExist:
+                    return Response({"success": False, "errors": {"cooling_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+                form = CoolingSystemChillerForm(data, instance=instance)
+            else:
+                form = CoolingSystemChillerForm(data)
+        elif ctype == "air_conditioner":
+            if is_update:
+                try:
+                    instance = CoolingSystemAirConditioner.objects.get(id=system_id, building=building)
+                except CoolingSystemAirConditioner.DoesNotExist:
+                    return Response({"success": False, "errors": {"cooling_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+                form = CoolingSystemAirConditionerForm(data, instance=instance)
+            else:
+                form = CoolingSystemAirConditionerForm(data)
+        else:
+            return Response({"success": False, "errors": {"cooling_system_type": ["Must be 'chiller' or 'air_conditioner'."]}}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not form.is_valid():
+            return Response({"success": False, "errors": form.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        return Response({
+            "success": True,
+            "cooling_system": {"id": system.id, "cooling_system_type": ctype},
+        }, status=status.HTTP_200_OK if is_update else status.HTTP_201_CREATED)
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("cooling_system_id")
+        ctype = data.get("cooling_system_type")
+
+        model = CoolingSystemChiller if ctype == "chiller" else CoolingSystemAirConditioner
+        try:
+            system = model.objects.get(id=system_id, building=building)
+        except model.DoesNotExist:
+            return Response({"success": False, "errors": {"cooling_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        system.delete()
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — Ventilation Systems (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddVentilationSystemView(APIView):
+    """
+    POST /api/buildings/add/ventilation-systems/  — create/update
+    DELETE /api/buildings/add/ventilation-systems/ — delete
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("ventilation_system_id")
+        is_update = bool(system_id)
+
+        if is_update:
+            try:
+                instance = VentilationSystem.objects.get(id=system_id, building=building)
+            except VentilationSystem.DoesNotExist:
+                return Response({"success": False, "errors": {"ventilation_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+            form = VentilationSystemForm(data, instance=instance)
+        else:
+            form = VentilationSystemForm(data)
+
+        if not form.is_valid():
+            return Response({"success": False, "errors": form.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        return Response({"success": True, "ventilation_system": {"id": system.id}},
+                        status=status.HTTP_200_OK if is_update else status.HTTP_201_CREATED)
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("ventilation_system_id")
+        try:
+            system = VentilationSystem.objects.get(id=system_id, building=building)
+        except VentilationSystem.DoesNotExist:
+            return Response({"success": False, "errors": {"ventilation_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        system.delete()
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — Lighting Systems (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddLightingSystemView(APIView):
+    """
+    POST /api/buildings/add/lighting-systems/  — create/update
+    DELETE /api/buildings/add/lighting-systems/ — delete
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("lighting_system_id")
+        is_update = bool(system_id)
+
+        if is_update:
+            try:
+                instance = LightingSystem.objects.get(id=system_id, building=building)
+            except LightingSystem.DoesNotExist:
+                return Response({"success": False, "errors": {"lighting_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+            form = LightingSystemForm(data, instance=instance)
+        else:
+            form = LightingSystemForm(data)
+
+        if not form.is_valid():
+            return Response({"success": False, "errors": form.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        return Response({"success": True, "lighting_system": {"id": system.id}},
+                        status=status.HTTP_200_OK if is_update else status.HTTP_201_CREATED)
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("lighting_system_id")
+        try:
+            system = LightingSystem.objects.get(id=system_id, building=building)
+        except LightingSystem.DoesNotExist:
+            return Response({"success": False, "errors": {"lighting_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        system.delete()
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — Lift & Escalator (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddLiftEscalatorView(APIView):
+    """
+    POST /api/buildings/add/lift-escalator/   — create/update (one per building)
+    DELETE /api/buildings/add/lift-escalator/ — delete
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("lift_escalator_system_id")
+        is_update = bool(system_id)
+
+        if is_update:
+            try:
+                instance = LiftEscalatorSystem.objects.get(id=system_id, building=building)
+            except LiftEscalatorSystem.DoesNotExist:
+                return Response({"success": False, "errors": {"lift_escalator_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+            form = LiftEscalatorSystemForm(data, instance=instance)
+        else:
+            if LiftEscalatorSystem.objects.filter(building=building).exists():
+                return Response(
+                    {"success": False, "errors": {"building": ["Only one lift & escalator system is allowed per building."]}},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            form = LiftEscalatorSystemForm(data)
+
+        if not form.is_valid():
+            return Response({"success": False, "errors": form.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        return Response(
+            {"success": True, "lift_escalator_system": {"id": system.id, "number_of_lifts": system.number_of_lifts}},
+            status=status.HTTP_200_OK if is_update else status.HTTP_201_CREATED,
+        )
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("lift_escalator_system_id")
+        try:
+            system = LiftEscalatorSystem.objects.get(id=system_id, building=building)
+        except LiftEscalatorSystem.DoesNotExist:
+            return Response({"success": False, "errors": {"lift_escalator_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        system.delete()
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — Hot Water Systems (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddHotWaterSystemView(APIView):
+    """
+    POST /api/buildings/add/hot-water-systems/   — create/update
+    DELETE /api/buildings/add/hot-water-systems/ — delete
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("hot_water_system_id")
+        is_update = bool(system_id)
+
+        if is_update:
+            try:
+                instance = HotWaterSystem.objects.get(id=system_id, building=building)
+            except HotWaterSystem.DoesNotExist:
+                return Response({"success": False, "errors": {"hot_water_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+            form = HotWaterSystemForm(data, instance=instance)
+        else:
+            form = HotWaterSystemForm(data)
+
+        if not form.is_valid():
+            return Response({"success": False, "errors": form.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        return Response({"success": True, "hot_water_system": {"id": system.id}},
+                        status=status.HTTP_200_OK if is_update else status.HTTP_201_CREATED)
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        system_id = data.get("hot_water_system_id")
+        try:
+            system = HotWaterSystem.objects.get(id=system_id, building=building)
+        except HotWaterSystem.DoesNotExist:
+            return Response({"success": False, "errors": {"hot_water_system_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        system.delete()
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — Energy Carriers (Operational Products)
+# ---------------------------------------------------------------------------
+
+class BuildingAddEnergyCarriersView(APIView):
+    """
+    POST /api/buildings/add/energy-carriers/
+
+    Saves/replaces operational products for the building.
+
+    Body:
+    {
+        "building_uuid": str,
+        "products": [
+            {"epd_id": str (UUID), "quantity": float, "input_unit": str, "description": str},
+            ...
+        ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        products_payload = data.get("products", [])
+        errors = {}
+        to_save = []
+
+        for idx, item in enumerate(products_payload):
+            label = f"product {idx + 1}"
+            epd_id = _str(item.get("epd_id"))
+            quantity_raw = item.get("quantity")
+            input_unit = _str(item.get("input_unit"))
+            description = _str(item.get("description"))
+
+            if not epd_id:
+                errors[label] = {"epd_id": ["EPD ID is required."]}
+                continue
+
+            try:
+                epd = EPD.objects.get(pk=uuid_lib.UUID(epd_id))
+            except (ValueError, EPD.DoesNotExist):
+                errors[label] = {"epd_id": [f"EPD not found: {epd_id}"]}
+                continue
+
+            try:
+                quantity = float(quantity_raw)
+                if quantity <= 0:
+                    raise ValueError
+            except (ValueError, TypeError):
+                errors[label] = {"quantity": ["Must be a positive number."]}
+                continue
+
+            if not input_unit:
+                errors[label] = {"input_unit": ["Unit is required."]}
+                continue
+
+            to_save.append({"epd": epd, "quantity": quantity, "input_unit": input_unit, "description": description})
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            OperationalProduct.objects.filter(building=building).delete()
+            for item in to_save:
+                OperationalProduct.objects.create(
+                    building=building,
+                    epd=item["epd"],
+                    quantity=item["quantity"],
+                    input_unit=item["input_unit"],
+                    description=item["description"],
+                )
+
+        logger.info("API Add energy carriers: %d product(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — Structural Components (CRUD)
+# ---------------------------------------------------------------------------
+
+class BuildingAddStructuralComponentView(APIView):
+    """
+    POST /api/buildings/add/structural-components/
+
+    Creates one assembly + links it to the building.
+
+    Body:
+    {
+        "building_uuid": str,
+        "title": str,
+        "category_id": int (AssemblyCategory PK),
+        "technique_name": str (optional),
+        "dimension": str (area|length|mass|volume|pieces|pcs),
+        "quantity": float,
+        "unit": str (m2|m3|m|kg|ton|pcs),
+        "comment": str (optional),
+        "reporting_life_cycle": int (default 50),
+        "materials": [
+            {"epd_id": str (UUID), "quantity": float, "input_unit": str},
+            ...
+        ]
+    }
+
+    DELETE /api/buildings/add/structural-components/
+    {
+        "building_uuid": str,
+        "building_assembly_id": int (BuildingAssembly PK)
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        from pages.models.assembly import AssemblyCategory
+        from pages.views.building.import_building import DIMENSION_MAP, STRUCTURAL_UNIT_MAP
+
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        errors = {}
+
+        title = _str(data.get("title")) or "Unnamed Assembly"
+        category_id = data.get("category_id")
+        technique_name = _str(data.get("technique_name"))
+        dim_raw = _str(data.get("dimension", "")).lower()
+        qty_raw = data.get("quantity")
+        unit_raw = _str(data.get("unit", "")).lower()
+        comment = _str(data.get("comment"))
+        reporting_life_cycle = int(data.get("reporting_life_cycle") or 50)
+        materials_payload = data.get("materials", [])
+
+        try:
+            category = AssemblyCategory.objects.get(pk=category_id)
+        except (AssemblyCategory.DoesNotExist, TypeError, ValueError):
+            errors["category_id"] = "Unknown building component category."
+
+        dim_val = DIMENSION_MAP.get(dim_raw)
+        if not dim_val:
+            errors["dimension"] = f"Unknown dimension '{dim_raw}'."
+
+        try:
+            asm_qty = float(qty_raw)
+            if asm_qty <= 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            errors["quantity"] = f"Invalid quantity."
+
+        asm_unit = STRUCTURAL_UNIT_MAP.get(unit_raw)
+        if not asm_unit:
+            errors["unit"] = f"Unknown unit '{unit_raw}'."
+
+        materials = []
+        for idx, mat in enumerate(materials_payload):
+            mat_label = f"material {idx + 1}"
+            epd_id = _str(mat.get("epd_id"))
+            mat_qty_raw = mat.get("quantity")
+            mat_unit = _str(mat.get("input_unit"))
+
+            if not epd_id:
+                errors[mat_label] = {"epd_id": ["Required."]}
+                continue
+            try:
+                epd = EPD.objects.get(pk=uuid_lib.UUID(epd_id))
+            except (ValueError, EPD.DoesNotExist):
+                errors[mat_label] = {"epd_id": [f"EPD not found: {epd_id}"]}
+                continue
+            try:
+                mat_qty = float(mat_qty_raw)
+                if mat_qty <= 0:
+                    raise ValueError
+            except (ValueError, TypeError):
+                errors[mat_label] = {"quantity": ["Must be a positive number."]}
+                continue
+
+            materials.append({"epd": epd, "quantity": mat_qty, "input_unit": mat_unit})
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        classification = None
+        if technique_name:
+            try:
+                technique = AssemblyTechnique.objects.get(name__iexact=technique_name.strip())
+                classification = AssemblyCategoryTechnique.objects.filter(
+                    category=category, technique=technique,
+                ).first()
+            except AssemblyTechnique.DoesNotExist:
+                pass
+
+        with transaction.atomic():
+            assembly = Assembly.objects.create(
+                created_by=request.user,
+                name=title,
+                comment=comment,
+                dimension=dim_val,
+                mode=AssemblyMode.CUSTOM,
+                is_boq=False,
+                is_template=False,
+                public=False,
+                draft=False,
+            )
+            for mat in materials:
+                StructuralProduct.objects.create(
+                    epd=mat["epd"],
+                    assembly=assembly,
+                    quantity=mat["quantity"],
+                    input_unit=mat["input_unit"],
+                    classification=classification,
+                )
+            ba = BuildingAssembly.objects.create(
+                building=building,
+                assembly=assembly,
+                quantity=asm_qty,
+                reporting_life_cycle=reporting_life_cycle,
+            )
+
+        logger.info("API Add structural: assembly %s created for building %s by %s", assembly.id, building.uuid, request.user)
+        return Response({"success": True, "building_assembly_id": ba.id, "assembly_id": assembly.id}, status=status.HTTP_201_CREATED)
+
+    def delete(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        ba_id = data.get("building_assembly_id")
+        try:
+            ba = BuildingAssembly.objects.get(id=ba_id, building=building)
+        except BuildingAssembly.DoesNotExist:
+            return Response({"success": False, "errors": {"building_assembly_id": ["Not found."]}}, status=status.HTTP_404_NOT_FOUND)
+
+        assembly = ba.assembly
+        ba.delete()
+        # Delete the assembly itself if it's not linked to other buildings
+        if not BuildingAssembly.objects.filter(assembly=assembly).exists():
+            assembly.delete()
+
+        return Response({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Complete — publish the building
+# ---------------------------------------------------------------------------
+
+class BuildingAddCompleteView(APIView):
+    """
+    POST /api/buildings/add/complete/
+    Marks a building as published (draft=False).
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        building, err = _get_building_or_error(request, _str(request.data.get("building_uuid")))
+        if err:
+            return err
+
+        building.draft = False
+        building.save()
+
+        logger.info("API Add: building %s published by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})

--- a/api/views/building_detail.py
+++ b/api/views/building_detail.py
@@ -1,0 +1,357 @@
+"""
+API view for the full building detail page.
+
+GET /api/buildings/<uuid>/detail/
+
+Returns everything the HTMX building detail page shows:
+  - Core building fields (same as AdminBuildingSerializer)
+  - Full operational schedule & temperature settings
+  - All operational systems (cooling, ventilation, lighting, lift, hot water)
+  - All operational products (energy carriers)
+  - All structural assemblies with their materials
+  - Carbon statistics (footprint, embodied, operational, savings %)
+  - Chart data (embodied by assembly, embodied by material, operational by system)
+"""
+
+import logging
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.permissions import IsAdminUser
+from api.views.buildings import _buildings_queryset
+from pages.models.building import Building
+from pages.models.building_operation import (
+    CoolingSystemAirConditioner, CoolingSystemChiller,
+    HotWaterSystem, LiftEscalatorSystem,
+)
+from pages.models.building_operation.ventilation import VentilationSystem
+from pages.models.building_operation.lighting import LightingSystem
+from pages.views.building.building_stats import (
+    calculate_total_carbon_footprint,
+    calculate_total_embodied_carbon,
+    calculate_total_operational_carbon,
+    calculate_carbon_savings_percentage,
+    get_embodied_carbon_by_assembly,
+    get_embodied_carbon_by_material,
+    get_operational_carbon_by_system,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_chiller(s):
+    return {
+        "id": s.id,
+        "cooling_system_type": "chiller",
+        "chiller_type": s.chiller_type,
+        "chiller_type_display": s.get_chiller_type_display(),
+        "year_of_installation": s.year_of_installation,
+        "refrigerant_type": s.refrigerant_type,
+        "refrigerant_quantity_kg": s.refrigerant_quantity_kg,
+        "variable_speed_drives": s.variable_speed_drives,
+        "heat_recovery_system": s.heat_recovery_system,
+        "total_cooling_load_rt": s.total_cooling_load_rt,
+        "baseline_leakage_factor_percent": s.baseline_leakage_factor_percent,
+        "operation_hours_per_workday": s.operation_hours_per_workday,
+        "workdays_per_week": s.workdays_per_week,
+        "workweeks_per_year": s.workweeks_per_year,
+        "baseline_cooling_efficiency_kw_h": s.baseline_cooling_efficiency_kw_h,
+        "number_of_chillers": s.number_of_chillers,
+        "total_chiller_system_power_input_kw": s.total_chiller_system_power_input_kw,
+        "water_cooled_chiller_cooling_load_factor_percent": s.water_cooled_chiller_cooling_load_factor_percent,
+        "cop": float(s.cop) if s.cop else None,
+        "ip_lv": float(s.ip_lv) if s.ip_lv else None,
+        "energy_efficiency_label": s.energy_efficiency_label,
+        "number_of_stars": s.number_of_stars,
+        "total_energy_consumption_kwh_per_year": s.total_energy_consumption_kwh_per_year,
+        "baseline_refrigerant_emission_factor": s.baseline_refrigerant_emission_factor,
+    }
+
+
+def _serialize_ac(s):
+    return {
+        "id": s.id,
+        "cooling_system_type": "air_conditioner",
+        "ac_type": s.ac_type,
+        "ac_type_display": s.get_ac_type_display(),
+        "packaged_subtype": s.packaged_subtype,
+        "packaged_subtype_display": s.get_packaged_subtype_display() if s.packaged_subtype else None,
+        "year_of_installation": s.year_of_installation,
+        "refrigerant_type": s.refrigerant_type,
+        "refrigerant_quantity_kg": s.refrigerant_quantity_kg,
+        "number_of_units_installed": s.number_of_units_installed,
+        "baseline_leakage_factor_percent": s.baseline_leakage_factor_percent,
+        "operation_hours_per_workday": s.operation_hours_per_workday,
+        "workdays_per_week": s.workdays_per_week,
+        "workweeks_per_year": s.workweeks_per_year,
+        "total_cooling_load_rt": s.total_cooling_load_rt,
+        "total_power_input_kw": float(s.total_power_input_kw) if s.total_power_input_kw else None,
+        "energy_efficiency_label": s.energy_efficiency_label,
+        "number_of_stars": s.number_of_stars,
+        "cop": float(s.cop) if s.cop else None,
+        "ip_lv": float(s.ip_lv) if s.ip_lv else None,
+        "total_energy_consumption_kwh_per_year": s.total_energy_consumption_kwh_per_year,
+        "baseline_refrigerant_emission_factor": s.baseline_refrigerant_emission_factor,
+    }
+
+
+def _serialize_ventilation(s):
+    return {
+        "id": s.id,
+        "ventilation_type": s.ventilation_type,
+        "ventilation_type_display": s.get_ventilation_type_display(),
+        "ventilation_capacity": s.ventilation_capacity,
+        "ventilation_capacity_display": s.get_ventilation_capacity_display() if s.ventilation_capacity else None,
+        "baseline_efficiency_w_cmh": float(s.baseline_efficiency_w_cmh) if s.baseline_efficiency_w_cmh else None,
+        "operation_hours_per_workday": s.operation_hours_per_workday,
+        "workdays_per_week": s.workdays_per_week,
+        "workweeks_per_year": s.workweeks_per_year,
+        "total_power_input_kw": float(s.total_power_input_kw) if s.total_power_input_kw else None,
+        "air_flow_rate": s.air_flow_rate,
+        "demand_controlled_ventilation": s.demand_controlled_ventilation,
+        "variable_speed_drives": s.variable_speed_drives,
+        "number_of_units_installed": s.number_of_units_installed,
+        "total_energy_consumption_kwh_per_year": s.total_energy_consumption_kwh_per_year,
+        "fresh_air_ratio_percent": s.fresh_air_ratio_percent,
+        "number_of_stars": s.number_of_stars,
+    }
+
+
+def _serialize_lighting(s):
+    return {
+        "id": s.id,
+        "room_type": s.room_type,
+        "room_type_display": s.get_room_type_display(),
+        "area_of_room": s.area_of_room,
+        "lighting_bulb_type": s.lighting_bulb_type,
+        "lighting_bulb_type_display": s.get_lighting_bulb_type_display(),
+        "number_of_bulbs": s.number_of_bulbs,
+        "tubes_per_fixture": s.tubes_per_fixture,
+        "light_bulb_power_rating_w": s.light_bulb_power_rating_w,
+        "total_lighting_power_kw": float(s.total_lighting_power_kw) if s.total_lighting_power_kw is not None else None,
+        "baseline_lighting_power_density": float(s.baseline_lighting_power_density) if s.baseline_lighting_power_density is not None else None,
+        "operation_hours_per_workday": s.operation_hours_per_workday,
+        "workdays_per_week": s.workdays_per_week,
+        "workweeks_per_year": s.workweeks_per_year,
+        "sensors_installed": s.sensors_installed,
+        "total_energy_consumption_kwh_per_year": s.total_energy_consumption_kwh_per_year,
+        "energy_efficiency_label": s.energy_efficiency_label,
+        "energy_efficiency_label_display": s.get_energy_efficiency_label_display() if s.energy_efficiency_label else None,
+        "number_of_stars": s.number_of_stars,
+    }
+
+
+def _serialize_lift(s):
+    return {
+        "id": s.id,
+        "number_of_lifts": s.number_of_lifts,
+        "lift_regenerative_features": s.lift_regenerative_features,
+        "vvvf_sleep_mode": s.vvvf_sleep_mode,
+        "annual_energy_consumption_kwh": s.annual_energy_consumption_kwh,
+    }
+
+
+def _serialize_hot_water(s):
+    return {
+        "id": s.id,
+        "type_of_hot_water_system": s.type_of_hot_water_system,
+        "type_of_hot_water_system_display": s.get_type_of_hot_water_system_display(),
+        "fuel_type": s.fuel_type,
+        "fuel_type_display": s.get_fuel_type_display(),
+        "number_of_equipment": s.number_of_equipment,
+        "operating_hours_per_day": str(s.operating_hours_per_day),
+        "operating_days_per_week": s.operating_days_per_week,
+        "operating_weeks_per_year": s.operating_weeks_per_year,
+        "baseline_efficiency": str(s.baseline_efficiency),
+        "heat_recovery_system": s.heat_recovery_system,
+        "equipment_efficiency_level": str(s.equipment_efficiency_level),
+        "power_input": str(s.power_input) if s.power_input is not None else None,
+        "total_energy_consumption_kwh_per_year": s.total_energy_consumption_kwh_per_year,
+        "total_fuel_consumption": str(s.total_fuel_consumption) if s.total_fuel_consumption is not None else None,
+        "fuel_consumption_unit": s.fuel_consumption_unit,
+    }
+
+
+def _serialize_operational_product(op):
+    return {
+        "id": op.id,
+        "epd": {
+            "id": str(op.epd.pk),
+            "name": op.epd.name,
+            "declared_unit": op.epd.declared_unit,
+            "country": op.epd.country.name if op.epd.country else None,
+        } if op.epd else None,
+        "quantity": float(op.quantity) if op.quantity else None,
+        "input_unit": op.input_unit,
+        "description": op.description,
+    }
+
+
+def _serialize_assembly(ba):
+    """Serialize a BuildingAssembly with its Assembly and materials."""
+    assembly = ba.assembly
+    materials = []
+    for sp in assembly.structuralproduct_set.select_related("epd", "classification__category", "classification__technique").all():
+        materials.append({
+            "id": sp.id,
+            "epd": {
+                "id": str(sp.epd.pk),
+                "name": sp.epd.name,
+                "declared_unit": sp.epd.declared_unit,
+                "country": sp.epd.country.name if sp.epd.country else None,
+            } if sp.epd else None,
+            "quantity": float(sp.quantity) if sp.quantity else None,
+            "input_unit": sp.input_unit,
+            "classification": {
+                "category": str(sp.classification.category) if sp.classification and sp.classification.category else None,
+                "technique": str(sp.classification.technique) if sp.classification and sp.classification.technique else None,
+            } if sp.classification else None,
+        })
+    return {
+        "building_assembly_id": ba.id,
+        "assembly_id": assembly.id,
+        "name": assembly.name,
+        "comment": assembly.comment,
+        "dimension": assembly.dimension,
+        "quantity": float(ba.quantity) if ba.quantity else None,
+        "reporting_life_cycle": ba.reporting_life_cycle,
+        "materials": materials,
+    }
+
+
+class BuildingFullDetailView(APIView):
+    """
+    GET /api/buildings/<uuid>/detail/
+
+    Returns the full building detail: core info, all systems, operational
+    products, structural assemblies, carbon statistics and chart data.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, pk):
+        try:
+            building = _buildings_queryset(request).get(pk=pk)
+        except Building.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        # Core fields
+        core = {
+            "id": str(building.pk),
+            "uuid": str(building.uuid),
+            "name": building.name,
+            "street": building.street or "",
+            "country": {"id": building.country_id, "name": building.country.name} if building.country else None,
+            "region": {"id": building.region_id, "name": building.region.name} if building.region else None,
+            "city": {"id": building.city_id, "name": building.city.name} if building.city else None,
+            "longitude": building.longitude,
+            "latitude": building.latitude,
+            "climate_zone": {"id": building.climate_zone.id, "name": building.climate_zone.name} if building.climate_zone else None,
+            "total_floor_area": str(building.total_floor_area),
+            "cond_floor_area": str(building.cond_floor_area) if building.cond_floor_area else None,
+            "floors_below_ground": building.floors_below_ground,
+            "construction_year": building.construction_year,
+            "reference_period": building.reference_period,
+            "category": {
+                "category_id": building.category.category_id,
+                "category_name": building.category.category.name if building.category.category else None,
+                "subcategory_id": building.category.subcategory_id,
+                "subcategory_name": building.category.subcategory.name if building.category.subcategory else None,
+            } if building.category else None,
+            "created_at": building.created_at.isoformat() if building.created_at else None,
+            "created_by": {
+                "id": str(building.created_by.id),
+                "name": building.created_by.get_full_name() or building.created_by.username,
+            } if building.created_by else None,
+            "organisation": {
+                "id": str(building.organisation.pk),
+                "name": building.organisation.name,
+            } if building.organisation else None,
+            "draft": building.draft,
+            "public": building.public,
+            "has_certification": building.has_certification,
+            "has_boq": building.has_boq,
+        }
+
+        # Operational schedule
+        schedule = {
+            "num_residents": building.num_residents,
+            "hours_per_workday": building.hours_per_workday,
+            "workdays_per_week": building.workdays_per_week,
+            "weeks_per_year": building.weeks_per_year,
+            "heating_temp": float(building.heating_temp) if building.heating_temp else None,
+            "heating_temp_unit": building.heating_temp_unit,
+            "cooling_temp": float(building.cooling_temp) if building.cooling_temp else None,
+            "cooling_temp_unit": building.cooling_temp_unit,
+            "renewable_energy_percent": float(building.renewable_energy_percent) if building.renewable_energy_percent else None,
+            "building_smart_system": building.building_smart_system,
+        }
+
+        # Operational systems
+        cooling_systems = (
+            [_serialize_chiller(s) for s in CoolingSystemChiller.objects.filter(building=building).order_by("id")] +
+            [_serialize_ac(s) for s in CoolingSystemAirConditioner.objects.filter(building=building).order_by("id")]
+        )
+        ventilation_systems = [_serialize_ventilation(s) for s in VentilationSystem.objects.filter(building=building).order_by("id")]
+        lighting_systems = [_serialize_lighting(s) for s in LightingSystem.objects.filter(building=building).order_by("id")]
+        lift_systems = [_serialize_lift(s) for s in LiftEscalatorSystem.objects.filter(building=building)]
+        hot_water_systems = [_serialize_hot_water(s) for s in HotWaterSystem.objects.filter(building=building).order_by("id")]
+
+        # Operational products
+        operational_products = [
+            _serialize_operational_product(op)
+            for op in building.operational_products.select_related("epd__country").all()
+        ]
+
+        # Structural assemblies
+        structural_components = [
+            _serialize_assembly(ba)
+            for ba in building.buildingassembly_set.select_related("assembly").prefetch_related(
+                "assembly__structuralproduct_set__epd__country",
+                "assembly__structuralproduct_set__classification__category",
+                "assembly__structuralproduct_set__classification__technique",
+            ).order_by("-assembly__created_at")
+        ]
+
+        # Carbon statistics
+        try:
+            embodied = calculate_total_embodied_carbon(building, simulated=False)
+            operational_carbon = calculate_total_operational_carbon(building, simulated=False)
+            stats = {
+                "total_carbon_footprint": float(embodied + operational_carbon),
+                "total_embodied_carbon": float(embodied),
+                "total_operational_carbon": float(operational_carbon),
+                "carbon_savings_percentage": float(calculate_carbon_savings_percentage(building)),
+            }
+        except Exception:
+            stats = {
+                "total_carbon_footprint": None,
+                "total_embodied_carbon": None,
+                "total_operational_carbon": None,
+                "carbon_savings_percentage": None,
+            }
+
+        # Chart data
+        try:
+            chart_data = {
+                "embodied_by_assembly": get_embodied_carbon_by_assembly(building),
+                "embodied_by_material": get_embodied_carbon_by_material(building),
+                "operational_by_system": get_operational_carbon_by_system(building),
+            }
+        except Exception:
+            chart_data = {}
+
+        return Response({
+            **core,
+            "schedule": schedule,
+            "cooling_systems": cooling_systems,
+            "ventilation_systems": ventilation_systems,
+            "lighting_systems": lighting_systems,
+            "lift_systems": lift_systems,
+            "hot_water_systems": hot_water_systems,
+            "operational_products": operational_products,
+            "structural_components": structural_components,
+            "stats": stats,
+            "chart_data": chart_data,
+        })

--- a/api/views/building_export.py
+++ b/api/views/building_export.py
@@ -1,0 +1,156 @@
+"""
+API view for exporting the building list to Excel (.xlsx).
+
+GET /api/buildings/export/
+
+Accepts the same query params as BuildingListView (search, country, city,
+climate_zone, draft, organisation) and returns an Excel file with one row
+per building.
+
+Columns:
+  Name, Country, City, Region, Climate Zone, Building Type, Subcategory,
+  Total Floor Area (m²), Construction Year, Assessment Period (years),
+  Draft, Public, Organisation, Created By, Created At,
+  Total Carbon Footprint (kgCO₂e/m²), Total Embodied Carbon (kgCO₂e/m²),
+  Total Operational Carbon (kgCO₂e/m²)
+"""
+
+import io
+import logging
+
+import openpyxl
+from django.db.models import Q
+from django.http import HttpResponse
+from rest_framework.views import APIView
+
+from api.permissions import IsAdminUser
+from api.views.buildings import _buildings_queryset
+from pages.views.building.building_stats import (
+    calculate_total_carbon_footprint,
+    calculate_total_embodied_carbon,
+    calculate_total_operational_carbon,
+)
+
+logger = logging.getLogger(__name__)
+
+HEADERS = [
+    "Name",
+    "Country",
+    "City",
+    "Region",
+    "Climate Zone",
+    "Building Type",
+    "Subcategory",
+    "Total Floor Area (m²)",
+    "Construction Year",
+    "Assessment Period (years)",
+    "Draft",
+    "Public",
+    "Organisation",
+    "Created By",
+    "Created At",
+    "Total Carbon Footprint (kgCO₂e/m²)",
+    "Total Embodied Carbon (kgCO₂e/m²)",
+    "Total Operational Carbon (kgCO₂e/m²)",
+]
+
+
+class BuildingExportView(APIView):
+    """
+    GET /api/buildings/export/
+
+    Streams an Excel file with all buildings accessible to the requesting admin.
+    Applies the same filters as the building list endpoint.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        qs = _buildings_queryset(request)
+
+        search = request.query_params.get("search", "").strip()
+        if search:
+            qs = qs.filter(
+                Q(name__icontains=search) |
+                Q(city__name__icontains=search) |
+                Q(country__name__icontains=search) |
+                Q(street__icontains=search)
+            ).distinct()
+
+        country = request.query_params.get("country", "").strip()
+        if country:
+            qs = qs.filter(country__name__icontains=country)
+
+        city = request.query_params.get("city", "").strip()
+        if city:
+            qs = qs.filter(city__name__icontains=city)
+
+        climate_zone = request.query_params.get("climate_zone", "").strip()
+        if climate_zone:
+            qs = qs.filter(climate_zone__name__iexact=climate_zone)
+
+        draft = request.query_params.get("draft", "").strip().lower()
+        if draft in ("true", "false"):
+            qs = qs.filter(draft=(draft == "true"))
+
+        organisation = request.query_params.get("organisation", "").strip()
+        if organisation:
+            qs = qs.filter(organisation__id=organisation)
+
+        # Build workbook
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Buildings"
+
+        # Header row (bold)
+        ws.append(HEADERS)
+        for cell in ws[1]:
+            cell.font = openpyxl.styles.Font(bold=True)
+
+        # Data rows
+        for building in qs.iterator():
+            try:
+                embodied = calculate_total_embodied_carbon(building, simulated=False)
+                operational = calculate_total_operational_carbon(building, simulated=False)
+                footprint = embodied + operational
+            except Exception:
+                embodied = operational = footprint = None
+
+            row = [
+                building.name,
+                building.country.name if building.country else "",
+                building.city.name if building.city else "",
+                building.region.name if building.region else "",
+                building.climate_zone.name if building.climate_zone else "",
+                building.category.category.name if building.category and building.category.category else "",
+                building.category.subcategory.name if building.category and building.category.subcategory else "",
+                float(building.total_floor_area) if building.total_floor_area else "",
+                building.construction_year or "",
+                building.reference_period or "",
+                "Yes" if building.draft else "No",
+                "Yes" if building.public else "No",
+                building.organisation.name if building.organisation else "",
+                building.created_by.get_full_name() or building.created_by.username if building.created_by else "",
+                building.created_at.strftime("%Y-%m-%d %H:%M") if building.created_at else "",
+                float(footprint) if footprint is not None else "",
+                float(embodied) if embodied is not None else "",
+                float(operational) if operational is not None else "",
+            ]
+            ws.append(row)
+
+        # Auto-size columns (approximate)
+        for col in ws.columns:
+            max_len = max((len(str(cell.value)) if cell.value else 0) for cell in col)
+            ws.column_dimensions[col[0].column_letter].width = min(max_len + 4, 50)
+
+        # Stream response
+        output = io.BytesIO()
+        wb.save(output)
+        output.seek(0)
+
+        response = HttpResponse(
+            output.read(),
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        response["Content-Disposition"] = 'attachment; filename="buildings_export.xlsx"'
+        logger.info("API: building export requested by %s (%d rows)", request.user, qs.count())
+        return response

--- a/api/views/buildings.py
+++ b/api/views/buildings.py
@@ -1,0 +1,1234 @@
+import logging
+import uuid as uuid_lib
+
+from django.db import transaction
+from django.db.models import Q
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.permissions import IsAdminUser
+from api.serializers.organisation import AdminBuildingSerializer
+from api.utils import paginate_queryset
+from pages.models.assembly import (
+    Assembly, AssemblyCategory, AssemblyDimension, AssemblyMode,
+    AssemblyCategoryTechnique, StructuralProduct,
+)
+from pages.models.building import Building, BuildingBoQFile, CategorySubcategory, OperationalProduct
+from pages.models.epd import EPD, EPDType, Unit
+from pages.models.organisation import Organisation
+from pages.views.building.building_stats import (
+    calculate_total_carbon_footprint,
+    calculate_total_embodied_carbon,
+    calculate_total_operational_carbon,
+)
+from pages.views.building.import_building import (
+    _str,
+    _bool_from_excel,
+    _resolve_country,
+    _resolve_region,
+    _resolve_city,
+    _resolve_building_type,
+    _resolve_climate,
+    _parse_cooling_rows,
+    _parse_ventilation_rows,
+    _parse_lighting_rows,
+    _parse_hot_water_rows,
+    _lookup_energy_carrier_epd,
+    _get_structural_category_map,
+    _lookup_structural_epd,
+    COOLING_TAB_MAP,
+    VENTILATION_TAB_MAP,
+    LIGHTING_TAB_LAYOUT,
+    HOT_WATER_TAB_MAP,
+    DIMENSION_MAP,
+    STRUCTURAL_UNIT_MAP,
+)
+from pages.forms.cooling_system_form import CoolingSystemAirConditionerForm, CoolingSystemChillerForm
+from pages.forms.ventilation_system_form import VentilationSystemForm
+from pages.forms.lighting_system_form import LightingSystemForm
+from pages.forms.lift_escalator_system_form import LiftEscalatorSystemForm
+from pages.forms.hot_water_system_form import HotWaterSystemForm
+from pages.models.building_operation import LiftEscalatorSystem
+
+logger = logging.getLogger(__name__)
+
+
+def _buildings_queryset(request):
+    """
+    Return a Building queryset accessible by the requesting admin.
+    Superadmin sees all buildings that belong to an organisation.
+    Regular admin sees only buildings in their organisations.
+    """
+    qs = Building.objects.select_related(
+        "country", "city", "region",
+        "category__category", "category__subcategory",
+        "created_by", "organisation", "climate_zone",
+    )
+
+    if request.user.is_superuser:
+        qs = qs.filter(organisation__isnull=False)
+    else:
+        orgs = Organisation.objects.filter(memberships__user=request.user)
+        qs = qs.filter(organisation__in=orgs)
+
+    return qs
+
+
+class BuildingListView(APIView):
+    """
+    GET /api/buildings/
+    Lists all buildings across all organisations the admin can access.
+    Superadmin sees all buildings that belong to any organisation.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        qs = _buildings_queryset(request)
+
+        search = request.query_params.get("search", "").strip()
+        if search:
+            qs = qs.filter(
+                Q(name__icontains=search) |
+                Q(city__name__icontains=search) |
+                Q(country__name__icontains=search) |
+                Q(category__category__name__icontains=search) |
+                Q(category__subcategory__name__icontains=search) |
+                Q(street__icontains=search)
+            ).distinct()
+
+        country = request.query_params.get("country", "").strip()
+        if country:
+            qs = qs.filter(country__name__icontains=country)
+
+        city = request.query_params.get("city", "").strip()
+        if city:
+            qs = qs.filter(city__name__icontains=city)
+
+        climate_zone = request.query_params.get("climate_zone", "").strip()
+        if climate_zone:
+            qs = qs.filter(climate_zone__name__iexact=climate_zone)
+
+        draft = request.query_params.get("draft", "").strip().lower()
+        if draft in ("true", "false"):
+            qs = qs.filter(draft=(draft == "true"))
+
+        organisation = request.query_params.get("organisation", "").strip()
+        if organisation:
+            qs = qs.filter(organisation__id=organisation)
+
+        items, meta = paginate_queryset(qs, request)
+
+        stats_map = {}
+        for building in items:
+            try:
+                stats_map[str(building.pk)] = {
+                    "total_carbon_footprint": calculate_total_carbon_footprint(building),
+                    "total_embodied_carbon": calculate_total_embodied_carbon(building),
+                    "total_operational_carbon": calculate_total_operational_carbon(building),
+                }
+            except Exception:
+                stats_map[str(building.pk)] = {}
+
+        serializer = AdminBuildingSerializer(items, many=True, context={"stats": stats_map})
+        return Response({"results": serializer.data, "pagination": meta})
+
+
+class BuildingDetailView(APIView):
+    """
+    GET /api/buildings/<pk>/
+    Returns full detail for a single building.
+    """
+    permission_classes = [IsAdminUser]
+
+    def _get_building(self, pk, request):
+        try:
+            qs = _buildings_queryset(request)
+            return qs.get(pk=pk)
+        except Building.DoesNotExist:
+            return None
+
+    def get(self, request, pk):
+        building = self._get_building(pk, request)
+        if building is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        try:
+            stats = {
+                str(building.pk): {
+                    "total_carbon_footprint": calculate_total_carbon_footprint(building),
+                    "total_embodied_carbon": calculate_total_embodied_carbon(building),
+                    "total_operational_carbon": calculate_total_operational_carbon(building),
+                }
+            }
+        except Exception:
+            stats = {}
+        serializer = AdminBuildingSerializer(building, context={"stats": stats})
+        return Response(serializer.data)
+
+
+# ---------------------------------------------------------------------------
+# Import / Add building — step endpoints
+# ---------------------------------------------------------------------------
+
+class BuildingImportNameLocationView(APIView):
+    """
+    POST /api/buildings/import/name-location/
+    Step 1: Create or update a building's name and location.
+    Accepts organisation_id to link the building to an organisation.
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        errors = {}
+
+        building_name = _str(data.get("building_name"))
+        address = _str(data.get("address"))
+        country_name = _str(data.get("country"))
+        region_name = _str(data.get("region"))
+        city_name = _str(data.get("city"))
+        longitude = data.get("longitude") or None
+        latitude = data.get("latitude") or None
+        building_uuid = _str(data.get("building_uuid"))
+        organisation_id = _str(data.get("organisation_id"))
+
+        if not building_name:
+            errors["building_name"] = "Building name is required."
+        if not address:
+            errors["address"] = "Address is required."
+
+        country, country_err = _resolve_country(country_name)
+        if country_err:
+            errors["country"] = country_err
+
+        region = None
+        if country and region_name:
+            region, region_err = _resolve_region(region_name, country)
+            if region_err:
+                errors["region"] = region_err
+
+        city = None
+        if country:
+            city, city_err = _resolve_city(city_name, country)
+            if city_err:
+                errors["city"] = city_err
+        elif not city_name:
+            errors["city"] = "City is required."
+
+        # Resolve organisation
+        organisation = None
+        if organisation_id:
+            try:
+                org_qs = Organisation.objects.all()
+                if not request.user.is_superuser:
+                    org_qs = org_qs.filter(memberships__user=request.user)
+                organisation = org_qs.get(pk=organisation_id)
+            except Organisation.DoesNotExist:
+                errors["organisation_id"] = "Organisation not found or access denied."
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            longitude = float(longitude) if longitude else None
+        except (ValueError, TypeError):
+            longitude = None
+        try:
+            latitude = float(latitude) if latitude else None
+        except (ValueError, TypeError):
+            latitude = None
+
+        if building_uuid:
+            try:
+                uuid_obj = uuid_lib.UUID(building_uuid)
+                qs = _buildings_queryset(request)
+                building = qs.get(uuid=uuid_obj)
+                building.name = building_name
+                building.street = address
+                building.country = country
+                building.region = region
+                building.city = city
+                building.longitude = longitude
+                building.latitude = latitude
+                if organisation:
+                    building.organisation = organisation
+                building.save()
+            except (ValueError, Building.DoesNotExist):
+                return Response(
+                    {"success": False, "errors": {"__all__": ["Invalid building UUID."]}},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        else:
+            building = Building.objects.create(
+                name=building_name,
+                street=address,
+                country=country,
+                region=region,
+                city=city,
+                longitude=longitude,
+                latitude=latitude,
+                created_by=request.user,
+                organisation=organisation,
+                climate_zone=None,
+                total_floor_area=100,
+                reference_period=50,
+            )
+
+        logger.info("API Import Step 1: building %s saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+class BuildingImportDetailsView(APIView):
+    """
+    POST /api/buildings/import/details/
+    Step 2: Building type, climate zone, floor area, certification/BoQ files.
+    Expects multipart/form-data.
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        import os
+
+        building_uuid_str = _str(request.data.get("building_uuid"))
+        if not building_uuid_str:
+            return Response(
+                {"success": False, "errors": {"__all__": ["building_uuid is required."]}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid_str)
+            qs = _buildings_queryset(request)
+            building = qs.get(uuid=uuid_obj)
+        except (ValueError, Building.DoesNotExist):
+            return Response(
+                {"success": False, "errors": {"__all__": ["Building not found."]}},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        errors = {}
+
+        cat_subcat, bt_err = _resolve_building_type(_str(request.data.get("building_type")))
+        if bt_err:
+            errors["building_type"] = bt_err
+
+        climate_value, climate_err = _resolve_climate(request.data.get("climate_type"))
+        if climate_err:
+            errors["climate_type"] = climate_err
+
+        assessment_period_raw = _str(request.data.get("assessment_period"))
+        assessment_period = None
+        if not assessment_period_raw:
+            errors["assessment_period"] = "Assessment period is required."
+        else:
+            try:
+                assessment_period = int(float(assessment_period_raw))
+                if assessment_period <= 0:
+                    errors["assessment_period"] = "Assessment period must be a positive number."
+            except (ValueError, TypeError):
+                errors["assessment_period"] = "Assessment period must be a valid number."
+
+        total_floor_area_raw = _str(request.data.get("total_floor_area"))
+        total_floor_area = None
+        if not total_floor_area_raw:
+            errors["total_floor_area"] = "Total floor area is required."
+        else:
+            try:
+                total_floor_area = float(total_floor_area_raw)
+                if total_floor_area <= 0:
+                    errors["total_floor_area"] = "Total floor area must be greater than zero."
+            except (ValueError, TypeError):
+                errors["total_floor_area"] = "Total floor area must be a valid number."
+
+        conditioned_floor_area = None
+        cfa_raw = _str(request.data.get("conditioned_floor_area"))
+        if cfa_raw:
+            try:
+                conditioned_floor_area = float(cfa_raw)
+            except (ValueError, TypeError):
+                errors["conditioned_floor_area"] = "Conditioned floor area must be a valid number."
+
+        construction_year = None
+        cy_raw = _str(request.data.get("construction_year"))
+        if cy_raw:
+            try:
+                construction_year = int(float(cy_raw))
+            except (ValueError, TypeError):
+                errors["construction_year"] = "Construction year must be a valid year."
+
+        floors_below_ground = None
+        fbg_raw = _str(request.data.get("floors_below_ground"))
+        if fbg_raw:
+            try:
+                floors_below_ground = int(float(fbg_raw))
+            except (ValueError, TypeError):
+                errors["floors_below_ground"] = "Floors below ground must be a valid number."
+
+        has_certification = _bool_from_excel(request.data.get("has_certification", "no"))
+        has_boq = _bool_from_excel(request.data.get("has_boq", "no"))
+
+        from pages.views.building.building_step_files import _validate_file
+
+        if has_certification:
+            cert_file = request.FILES.get("certification_file")
+            if not cert_file:
+                errors["certification_file"] = "A certification file is required when 'Has certification' is Yes."
+            else:
+                cert_err = _validate_file(cert_file)
+                if cert_err:
+                    errors["certification_file"] = f"Certification file: {cert_err}"
+
+        if has_boq:
+            boq_files = request.FILES.getlist("boq_files")
+            if not boq_files:
+                errors["boq_files"] = "At least one BoQ file is required when 'Has BoQ' is Yes."
+            else:
+                for f in boq_files:
+                    boq_err = _validate_file(f)
+                    if boq_err:
+                        errors["boq_files"] = f"BoQ file '{f.name}': {boq_err}"
+                        break
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        if cat_subcat:
+            building.category = cat_subcat
+        building.climate_zone = climate_value
+        building.reference_period = assessment_period
+        building.total_floor_area = total_floor_area
+
+        if conditioned_floor_area is not None:
+            building.cond_floor_area = conditioned_floor_area
+        if construction_year is not None:
+            building.construction_year = construction_year
+        if floors_below_ground is not None:
+            building.floors_below_ground = floors_below_ground
+
+        building.has_certification = has_certification
+        building.has_boq = has_boq
+
+        if has_certification:
+            cert_file = request.FILES.get("certification_file")
+            if cert_file:
+                if building.certification_file:
+                    try:
+                        old_path = building.certification_file.path
+                        if os.path.isfile(old_path):
+                            os.remove(old_path)
+                    except Exception:
+                        pass
+                building.certification_file = cert_file
+        else:
+            if building.certification_file:
+                try:
+                    old_path = building.certification_file.path
+                    if os.path.isfile(old_path):
+                        os.remove(old_path)
+                except Exception:
+                    pass
+                building.certification_file = None
+
+        building.save()
+
+        if has_boq:
+            new_boq_files = request.FILES.getlist("boq_files")
+            if new_boq_files:
+                for old_file in building.boq_files.all():
+                    try:
+                        if os.path.isfile(old_file.file.path):
+                            os.remove(old_file.file.path)
+                    except Exception:
+                        pass
+                    old_file.delete()
+                for f in new_boq_files:
+                    BuildingBoQFile.objects.create(
+                        building=building,
+                        file=f,
+                        original_filename=f.name,
+                    )
+        else:
+            for old_file in building.boq_files.all():
+                try:
+                    if os.path.isfile(old_file.file.path):
+                        os.remove(old_file.file.path)
+                except Exception:
+                    pass
+                old_file.delete()
+
+        logger.info("API Import Step 2: building %s details saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+class BuildingImportOperationalScheduleView(APIView):
+    """
+    POST /api/buildings/import/operational-schedule/
+    Step 3: Operational schedule and temperature settings.
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+
+        building_uuid_str = _str(data.get("building_uuid"))
+        if not building_uuid_str:
+            return Response(
+                {"success": False, "errors": {"__all__": ["building_uuid is required."]}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid_str)
+            qs = _buildings_queryset(request)
+            building = qs.get(uuid=uuid_obj)
+        except (ValueError, Building.DoesNotExist):
+            return Response(
+                {"success": False, "errors": {"__all__": ["Building not found."]}},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        from pages.views.building.import_building import _validate_int_range, _validate_decimal_range
+
+        errors = {}
+
+        num_residents, err = _validate_int_range(data.get("num_residents"), "Number of residents", 0, 100000)
+        if err:
+            errors["num_residents"] = err
+
+        hours_per_workday, err = _validate_int_range(data.get("hours_per_workday"), "Hours per workday", 0, 24)
+        if err:
+            errors["hours_per_workday"] = err
+
+        workdays_per_week, err = _validate_int_range(data.get("workdays_per_week"), "Workdays per week", 0, 7)
+        if err:
+            errors["workdays_per_week"] = err
+
+        weeks_per_year, err = _validate_int_range(data.get("weeks_per_year"), "Weeks per year", 0, 52)
+        if err:
+            errors["weeks_per_year"] = err
+
+        heating_temp, err = _validate_decimal_range(data.get("heating_temp"), "Heating temperature", 0, 120)
+        if err:
+            errors["heating_temp"] = err
+
+        cooling_temp, err = _validate_decimal_range(data.get("cooling_temp"), "Cooling temperature", 0, 120)
+        if err:
+            errors["cooling_temp"] = err
+
+        renewable_energy_percent, err = _validate_decimal_range(data.get("renewable_energy_percent"), "Renewable energy percent", 0, 100)
+        if err:
+            errors["renewable_energy_percent"] = err
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        fields = {
+            "num_residents": num_residents,
+            "hours_per_workday": hours_per_workday,
+            "workdays_per_week": workdays_per_week,
+            "weeks_per_year": weeks_per_year,
+            "heating_temp": heating_temp,
+            "cooling_temp": cooling_temp,
+            "renewable_energy_percent": renewable_energy_percent,
+        }
+        for field, val in fields.items():
+            if val is not None:
+                setattr(building, field, val)
+
+        heating_temp_unit = _str(data.get("heating_temp_unit")).upper()
+        if heating_temp_unit in ("CELSIUS", "FAHRENHEIT"):
+            building.heating_temp_unit = heating_temp_unit
+
+        cooling_temp_unit = _str(data.get("cooling_temp_unit")).upper()
+        if cooling_temp_unit in ("CELSIUS", "FAHRENHEIT"):
+            building.cooling_temp_unit = cooling_temp_unit
+
+        smart_system_raw = data.get("building_smart_system")
+        if smart_system_raw is not None:
+            building.building_smart_system = _bool_from_excel(smart_system_raw)
+
+        building.save()
+
+        logger.info("API Import Step 3: building %s operational schedule saved by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+class BuildingCompleteView(APIView):
+    """
+    POST /api/buildings/import/complete/
+    Marks a building as no longer draft (publishes it).
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        building_uuid_str = _str(request.data.get("building_uuid"))
+        if not building_uuid_str:
+            return Response(
+                {"success": False, "errors": {"__all__": ["building_uuid is required."]}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            uuid_obj = uuid_lib.UUID(building_uuid_str)
+            qs = _buildings_queryset(request)
+            building = qs.get(uuid=uuid_obj)
+        except (ValueError, Building.DoesNotExist):
+            return Response(
+                {"success": False, "errors": {"__all__": ["Building not found."]}},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        building.draft = False
+        building.save()
+
+        logger.info("API: building %s marked complete by %s", building.uuid, request.user)
+        return Response({"success": True, "building_uuid": str(building.uuid)})
+
+
+def _get_building_or_error(request, building_uuid_str):
+    """Helper: resolve building UUID and return (building, error_response)."""
+    if not building_uuid_str:
+        return None, Response(
+            {"success": False, "errors": {"__all__": ["building_uuid is required."]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    try:
+        uuid_obj = uuid_lib.UUID(building_uuid_str)
+        building = _buildings_queryset(request).get(uuid=uuid_obj)
+        return building, None
+    except (ValueError, Building.DoesNotExist):
+        return None, Response(
+            {"success": False, "errors": {"__all__": ["Building not found."]}},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+
+class BuildingImportCoolingSystemsView(APIView):
+    """
+    POST /api/buildings/import/cooling-systems/
+    Step 4: Import cooling systems from structured JSON payload.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "systems": [
+            {"tab": "Air Conditioning", "rows": [[col0, col1, ...], ...]},
+            {"tab": "Chiller", "rows": [[col0, col1, ...], ...]},
+            ...
+        ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        systems_payload = data.get("systems", [])
+        all_errors = {}
+        to_save = []
+
+        for tab_entry in systems_payload:
+            tab_name = _str(tab_entry.get("tab", "")).lower().replace(" ", "")
+            raw_rows = tab_entry.get("rows", [])
+
+            tab_key = None
+            for key in COOLING_TAB_MAP:
+                if key.replace(" ", "") in tab_name or tab_name in key.replace(" ", ""):
+                    tab_key = key
+                    break
+
+            if tab_key is None:
+                continue
+
+            parsed_rows = _parse_cooling_rows(tab_key, raw_rows)
+
+            for row_idx, row_data in enumerate(parsed_rows):
+                ctype = row_data.pop("cooling_system_type")
+                label = f"{tab_entry.get('tab', tab_key)} row {row_idx + 1}"
+
+                if ctype == 'chiller':
+                    form = CoolingSystemChillerForm(row_data)
+                else:
+                    form = CoolingSystemAirConditionerForm(row_data)
+
+                if form.is_valid():
+                    to_save.append((form, ctype))
+                else:
+                    all_errors[label] = {
+                        field: [str(e) for e in errs]
+                        for field, errs in form.errors.items()
+                    }
+
+        if all_errors:
+            return Response({"success": False, "errors": all_errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            for form, ctype in to_save:
+                system = form.save(commit=False)
+                system.building = building
+                system.save()
+
+        logger.info("API Import cooling: %d system(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+class BuildingImportVentilationSystemsView(APIView):
+    """
+    POST /api/buildings/import/ventilation-systems/
+    Step 5: Import ventilation systems from structured JSON payload.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "systems": [
+            {"tab": "AHU", "rows": [[col0, col1, ...], ...]},
+            {"tab": "FCU", "rows": [[col0, col1, ...], ...]},
+            ...
+        ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        systems_payload = data.get("systems", [])
+        all_errors = {}
+        to_save = []
+
+        for tab_entry in systems_payload:
+            tab_name = _str(tab_entry.get("tab", "")).lower().strip()
+            raw_rows = tab_entry.get("rows", [])
+
+            vent_type = None
+            for key, vtype in VENTILATION_TAB_MAP.items():
+                if key in tab_name or tab_name in key:
+                    vent_type = vtype
+                    break
+
+            if vent_type is None:
+                continue
+
+            parsed_rows = _parse_ventilation_rows(vent_type, raw_rows)
+
+            for row_idx, row_data in enumerate(parsed_rows):
+                label = f"{tab_entry.get('tab', tab_name)} row {row_idx + 1}"
+                form = VentilationSystemForm(row_data)
+
+                if form.is_valid():
+                    to_save.append(form)
+                else:
+                    all_errors[label] = {
+                        field: [str(e) for e in errs]
+                        for field, errs in form.errors.items()
+                    }
+
+        if all_errors:
+            return Response({"success": False, "errors": all_errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            for form in to_save:
+                system = form.save(commit=False)
+                system.building = building
+                system.save()
+
+        logger.info("API Import ventilation: %d system(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+class BuildingImportLightingSystemsView(APIView):
+    """
+    POST /api/buildings/import/lighting-systems/
+    Step 6: Import lighting systems from structured JSON payload.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "systems": [
+            {"tab": "LED", "rows": [[col0, col1, ...], ...]},
+            {"tab": "Fluorescent", "rows": [[col0, col1, ...], ...]},
+            ...
+        ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        systems_payload = data.get("systems", [])
+        all_errors = {}
+        to_save = []
+
+        for tab_entry in systems_payload:
+            tab_name = _str(tab_entry.get("tab", "")).lower().strip()
+            raw_rows = tab_entry.get("rows", [])
+
+            tab_layout = None
+            for key in LIGHTING_TAB_LAYOUT:
+                if key in tab_name or tab_name in key:
+                    tab_layout = key
+                    break
+
+            if tab_layout is None:
+                continue
+
+            parsed_rows = _parse_lighting_rows(tab_layout, raw_rows)
+
+            for row_idx, row_data in enumerate(parsed_rows):
+                label = f"{tab_entry.get('tab', tab_name)} row {row_idx + 1}"
+                form = LightingSystemForm(row_data)
+
+                if form.is_valid():
+                    to_save.append(form)
+                else:
+                    all_errors[label] = {
+                        field: [str(e) for e in errs]
+                        for field, errs in form.errors.items()
+                    }
+
+        if all_errors:
+            return Response({"success": False, "errors": all_errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            for form in to_save:
+                system = form.save(commit=False)
+                system.building = building
+                system.save()
+
+        logger.info("API Import lighting: %d system(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+class BuildingImportLiftEscalatorView(APIView):
+    """
+    POST /api/buildings/import/lift-escalator/
+    Step 7: Import lift & escalator system.
+
+    Only one lift & escalator system is allowed per building.
+    If the row is empty, the step is silently skipped.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "rows": [ [number_of_lifts, lift_regenerative_features, vvvf_sleep_mode], ... ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        raw_rows = data.get("rows", [])
+
+        row_data = None
+        for raw_row in raw_rows:
+            row = list(raw_row) + [None] * 5
+            num_lifts_raw = _str(row[0])
+            if num_lifts_raw:
+                row_data = {
+                    'number_of_lifts':           num_lifts_raw,
+                    'lift_regenerative_features': _str(row[1]) or 'no',
+                    'vvvf_sleep_mode':            _str(row[2]) or 'no',
+                }
+                break
+
+        if row_data is None:
+            return Response({"success": True, "saved_count": 0, "building_uuid": str(building.uuid)})
+
+        existing = LiftEscalatorSystem.objects.filter(building=building).first()
+        form = LiftEscalatorSystemForm(row_data, instance=existing)
+        if not form.is_valid():
+            return Response({"success": False, "errors": dict(form.errors)}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            system = form.save(commit=False)
+            system.building = building
+            system.save()
+
+        logger.info("API Import lift: system saved for building %s by %s", building.uuid, request.user)
+        return Response({"success": True, "saved_count": 1, "building_uuid": str(building.uuid)})
+
+
+class BuildingImportHotWaterSystemsView(APIView):
+    """
+    POST /api/buildings/import/hot-water-systems/
+    Step 8: Import hot water systems from structured JSON payload.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "systems": [
+            {"tab": "Boiler", "rows": [[col0, col1, ...], ...]},
+            {"tab": "Heat Pump", "rows": [[col0, col1, ...], ...]},
+            ...
+        ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        systems_payload = data.get("systems", [])
+        all_errors = {}
+        to_save = []
+
+        for tab_entry in systems_payload:
+            tab_name = _str(tab_entry.get("tab", "")).lower().strip()
+            raw_rows = tab_entry.get("rows", [])
+
+            hws_type = None
+            for key, val in HOT_WATER_TAB_MAP.items():
+                if key in tab_name or tab_name in key:
+                    hws_type = val
+                    break
+
+            if hws_type is None:
+                continue
+
+            parsed_rows = _parse_hot_water_rows(hws_type, raw_rows)
+
+            for row_idx, row_data in enumerate(parsed_rows):
+                label = f"{tab_entry.get('tab', tab_name)} row {row_idx + 1}"
+                form = HotWaterSystemForm(row_data)
+
+                if form.is_valid():
+                    to_save.append(form)
+                else:
+                    all_errors[label] = {
+                        field: [str(e) for e in errs]
+                        for field, errs in form.errors.items()
+                    }
+
+        if all_errors:
+            return Response({"success": False, "errors": all_errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            for form in to_save:
+                system = form.save(commit=False)
+                system.building = building
+                system.save()
+
+        logger.info("API Import hot water: %d system(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+class BuildingImportEnergyCarriersView(APIView):
+    """
+    POST /api/buildings/import/energy-carriers/
+    Step 9: Import operational energy carriers.
+
+    Existing OperationalProducts for the building are replaced.
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "rows": [ [name, description, quantity, unit], ... ]
+    }
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        raw_rows = data.get("rows", [])
+        if not raw_rows:
+            return Response({"success": True, "saved_count": 0, "building_uuid": str(building.uuid)})
+
+        errors = {}
+        to_save = []
+
+        unit_norm_map = {
+            'kwh': 'kwh', 'kilowatt hour': 'kwh', 'kilowatt-hour': 'kwh',
+            'kg': 'kg', 'kilogram': 'kg',
+            'm3': 'm3', 'm³': 'm3', 'cubic meter': 'm3', 'cubic metre': 'm3',
+            'l': 'l', 'liter': 'l', 'litre': 'l', 'liter ': 'l',
+        }
+
+        for row_idx, raw_row in enumerate(raw_rows):
+            row = list(raw_row) + [None] * 5
+            label = f"row {row_idx + 1}"
+
+            def cell(i):
+                v = row[i]
+                return '' if v is None else str(v).strip()
+
+            name_raw = cell(0)
+            description = cell(1)
+            quantity_raw = cell(2)
+            unit_raw = cell(3).lower()
+
+            if not name_raw:
+                continue
+
+            if not quantity_raw:
+                errors[label] = {"quantity": ["Quantity is required."]}
+                continue
+            try:
+                quantity = float(quantity_raw)
+                if quantity <= 0:
+                    errors[label] = {"quantity": ["Quantity must be greater than 0."]}
+                    continue
+            except (ValueError, TypeError):
+                errors[label] = {"quantity": [f"Invalid quantity: '{quantity_raw}'."]}
+                continue
+
+            if not unit_raw:
+                errors[label] = {"unit": ["Quantity unit is required."]}
+                continue
+
+            unit_norm = unit_norm_map.get(unit_raw, unit_raw)
+
+            epd, epd_error = _lookup_energy_carrier_epd(name_raw)
+            if epd_error:
+                errors[label] = {"name": [epd_error]}
+                continue
+
+            available = epd.get_available_units() or {epd.declared_unit}
+            available_lower = {str(u).lower() for u in available}
+            if unit_norm not in available_lower and unit_raw not in available_lower:
+                errors[label] = {
+                    "unit": [
+                        f"Unit '{unit_raw}' is not valid for '{epd.name}'. "
+                        f"Accepted: {', '.join(sorted(available_lower))}."
+                    ]
+                }
+                continue
+
+            to_save.append({
+                "epd": epd,
+                "quantity": quantity,
+                "input_unit": unit_norm,
+                "description": description,
+            })
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            OperationalProduct.objects.filter(building=building).delete()
+            for item in to_save:
+                OperationalProduct.objects.create(
+                    building=building,
+                    epd=item["epd"],
+                    quantity=item["quantity"],
+                    input_unit=item["input_unit"],
+                    description=item["description"],
+                )
+
+        logger.info("API Import energy carriers: %d product(s) saved for building %s by %s", len(to_save), building.uuid, request.user)
+        return Response({"success": True, "saved_count": len(to_save), "building_uuid": str(building.uuid)})
+
+
+class BuildingImportStructuralComponentsView(APIView):
+    """
+    POST /api/buildings/import/structural-components/
+    Step 10: Import structural components (by component).
+
+    Expects JSON:
+    {
+        "building_uuid": str,
+        "rows": [ [col0..col16], ... ]   (data rows only, headers stripped by client)
+    }
+
+    Column layout:
+      0:  Title
+      1:  Building Component  (→ AssemblyCategory)
+      2:  Construction Technique
+      3:  Dimension
+      4:  Quantity
+      5:  Units
+      6:  Comment
+      8:  EPD Name      (added material)
+      9:  Country       (added material country)
+      10: Quantity      (added material quantity)
+      11: Units         (added material unit)
+    """
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        data = request.data
+        building, err = _get_building_or_error(request, _str(data.get("building_uuid")))
+        if err:
+            return err
+
+        raw_rows = data.get("rows", [])
+        if not raw_rows:
+            return Response({"success": True, "saved_count": 0, "building_uuid": str(building.uuid)})
+
+        cat_map = _get_structural_category_map()
+        errors = {}
+        assemblies_to_create = []
+        current_assembly = None
+
+        for row_idx, raw_row in enumerate(raw_rows):
+            row = list(raw_row) + [None] * 17
+            label = f"row {row_idx + 1}"
+
+            def cell(i):
+                v = row[i]
+                return '' if v is None else str(v).strip()
+
+            title = cell(0)
+            comp_raw = cell(1)
+            tech_raw = cell(2)
+            dim_raw = cell(3)
+            qty_raw = cell(4)
+            unit_raw = cell(5)
+            comment = cell(6)
+            epd_name = cell(8)
+            epd_country = cell(9)
+            epd_qty = cell(10)
+            epd_unit = cell(11)
+
+            # Separator row
+            if comp_raw and not tech_raw and not qty_raw:
+                current_assembly = None
+                continue
+
+            # New assembly row
+            if comp_raw and qty_raw:
+                cat = cat_map.get(comp_raw.lower().strip())
+                if cat is None:
+                    errors[label] = {"building_component": [f"Unknown building component '{comp_raw}'."]}
+                    current_assembly = None
+                    continue
+
+                dim_val = DIMENSION_MAP.get(dim_raw.lower().strip())
+                if not dim_val:
+                    errors[label] = {"dimension": [f"Unknown dimension '{dim_raw}'."]}
+                    current_assembly = None
+                    continue
+
+                try:
+                    asm_qty = float(qty_raw)
+                    if asm_qty <= 0:
+                        raise ValueError
+                except (ValueError, TypeError):
+                    errors[label] = {"quantity": [f"Invalid quantity '{qty_raw}'."]}
+                    current_assembly = None
+                    continue
+
+                asm_unit = STRUCTURAL_UNIT_MAP.get(unit_raw.lower())
+                if not asm_unit:
+                    errors[label] = {"unit": [f"Unknown unit '{unit_raw}'."]}
+                    current_assembly = None
+                    continue
+
+                current_assembly = {
+                    "title": title or comp_raw,
+                    "category": cat,
+                    "technique_name": tech_raw,
+                    "dimension": dim_val,
+                    "quantity": asm_qty,
+                    "unit": asm_unit,
+                    "comment": comment,
+                    "materials": [],
+                }
+                assemblies_to_create.append(current_assembly)
+
+            # Material row
+            if epd_name and epd_qty:
+                if current_assembly is None:
+                    errors[label] = {"epd": ["Material row found without a preceding assembly row."]}
+                    continue
+
+                try:
+                    mat_qty = float(epd_qty)
+                    if mat_qty <= 0:
+                        raise ValueError
+                except (ValueError, TypeError):
+                    errors[label] = {"epd_quantity": [f"Invalid material quantity '{epd_qty}'."]}
+                    continue
+
+                epd, epd_error = _lookup_structural_epd(epd_name, epd_country)
+                if epd_error:
+                    errors[label] = {"epd_name": [epd_error]}
+                    continue
+
+                from pages.views.assembly.epd_dimension_info import get_epd_dimension_info
+                _, expected_unit = get_epd_dimension_info(current_assembly["dimension"], epd.declared_unit)
+
+                current_assembly["materials"].append({
+                    "epd": epd,
+                    "quantity": mat_qty,
+                    "unit": expected_unit,
+                })
+
+        assemblies_to_create = [a for a in assemblies_to_create if a["materials"]]
+
+        if errors:
+            return Response({"success": False, "errors": errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not assemblies_to_create:
+            return Response({"success": True, "saved_count": 0, "building_uuid": str(building.uuid)})
+
+        from pages.models.assembly import AssemblyTechnique
+
+        saved_count = 0
+        with transaction.atomic():
+            for asm_data in assemblies_to_create:
+                classification = None
+                if asm_data["technique_name"]:
+                    try:
+                        technique = AssemblyTechnique.objects.get(
+                            name__iexact=asm_data["technique_name"].strip()
+                        )
+                        classification = AssemblyCategoryTechnique.objects.filter(
+                            category=asm_data["category"],
+                            technique=technique,
+                        ).first()
+                    except AssemblyTechnique.DoesNotExist:
+                        pass
+
+                assembly = Assembly.objects.create(
+                    created_by=request.user,
+                    name=asm_data["title"],
+                    comment=asm_data["comment"],
+                    dimension=asm_data["dimension"],
+                    mode=AssemblyMode.CUSTOM,
+                    is_boq=False,
+                    is_template=False,
+                    public=False,
+                    draft=False,
+                )
+
+                for mat in asm_data["materials"]:
+                    StructuralProduct.objects.create(
+                        epd=mat["epd"],
+                        assembly=assembly,
+                        quantity=mat["quantity"],
+                        input_unit=mat["unit"],
+                        classification=classification,
+                    )
+
+                from pages.models.building import BuildingAssembly
+                BuildingAssembly.objects.create(
+                    building=building,
+                    assembly=assembly,
+                    quantity=asm_data["quantity"],
+                    reporting_life_cycle=50,
+                )
+
+                saved_count += 1
+
+        logger.info("API Import structural: %d assembly(ies) saved for building %s by %s", saved_count, building.uuid, request.user)
+        return Response({"success": True, "saved_count": saved_count, "building_uuid": str(building.uuid)})

--- a/api/views/buildings.py
+++ b/api/views/buildings.py
@@ -66,9 +66,7 @@ def _buildings_queryset(request):
         "created_by", "organisation", "climate_zone",
     )
 
-    if request.user.is_superuser:
-        qs = qs.filter(organisation__isnull=False)
-    else:
+    if not request.user.is_superuser:
         orgs = Organisation.objects.filter(memberships__user=request.user)
         qs = qs.filter(organisation__in=orgs)
 
@@ -585,7 +583,14 @@ class BuildingCompleteView(APIView):
 
 
 def _get_building_or_error(request, building_uuid_str):
-    """Helper: resolve building UUID and return (building, error_response)."""
+    """
+    Helper: resolve building UUID and return (building, error_response).
+
+    Access rules:
+    - Superadmin: any building
+    - Regular admin: buildings in their orgs OR buildings they created (draft,
+      no org yet — e.g. mid add-building flow)
+    """
     if not building_uuid_str:
         return None, Response(
             {"success": False, "errors": {"__all__": ["building_uuid is required."]}},
@@ -593,9 +598,33 @@ def _get_building_or_error(request, building_uuid_str):
         )
     try:
         uuid_obj = uuid_lib.UUID(building_uuid_str)
-        building = _buildings_queryset(request).get(uuid=uuid_obj)
+    except ValueError:
+        return None, Response(
+            {"success": False, "errors": {"__all__": ["Invalid building UUID."]}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if request.user.is_superuser:
+        qs = Building.objects.select_related(
+            "country", "city", "region",
+            "category__category", "category__subcategory",
+            "created_by", "organisation", "climate_zone",
+        )
+    else:
+        from pages.models.organisation import Organisation as Org
+        orgs = Org.objects.filter(memberships__user=request.user)
+        qs = Building.objects.select_related(
+            "country", "city", "region",
+            "category__category", "category__subcategory",
+            "created_by", "organisation", "climate_zone",
+        ).filter(
+            Q(organisation__in=orgs) | Q(created_by=request.user)
+        )
+
+    try:
+        building = qs.get(uuid=uuid_obj)
         return building, None
-    except (ValueError, Building.DoesNotExist):
+    except Building.DoesNotExist:
         return None, Response(
             {"success": False, "errors": {"__all__": ["Building not found."]}},
             status=status.HTTP_404_NOT_FOUND,

--- a/api/views/system_settings.py
+++ b/api/views/system_settings.py
@@ -1,6 +1,6 @@
 import logging
 
-from cities_light.models import Country
+from cities_light.models import Country, Region
 from django.db import transaction
 from rest_framework import status
 from rest_framework.response import Response
@@ -66,6 +66,53 @@ class CountryListCreateView(APIView):
                     CustomCity.objects.get_or_create(name=name, country=country)
 
         return Response(CountryDetailSerializer(country).data, status=status.HTTP_201_CREATED)
+
+
+class CountryRegionsView(APIView):
+    """
+    GET /api/system-settings/countries/<pk>/regions/
+    Returns all regions (states/provinces) for a given country.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, pk):
+        try:
+            country = Country.objects.get(pk=pk)
+        except Country.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        qs = Region.objects.filter(country=country).order_by("name")
+        search = request.query_params.get("search", "").strip()
+        if search:
+            qs = qs.filter(name__icontains=search)
+
+        data = [{"id": r.id, "name": r.name} for r in qs]
+        return Response({"results": data})
+
+
+class CountryCitiesView(APIView):
+    """
+    GET /api/system-settings/countries/<pk>/cities/
+    Returns all cities for a given country (id + name), optionally filtered by ?search=.
+    """
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, pk):
+        try:
+            country = Country.objects.get(pk=pk)
+        except Country.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        qs = CustomCity.objects.filter(country=country).order_by("name")
+        region_id = request.query_params.get("region_id", "").strip()
+        if region_id:
+            qs = qs.filter(region_id=region_id)
+        search = request.query_params.get("search", "").strip()
+        if search:
+            qs = qs.filter(name__icontains=search)
+
+        from api.serializers.system_settings import CitySerializer
+        return Response({"results": CitySerializer(qs, many=True).data})
 
 
 class CountryDetailView(APIView):

--- a/pages/migrations/0031_assembly_template_fields.py
+++ b/pages/migrations/0031_assembly_template_fields.py
@@ -1,14 +1,13 @@
-from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
     """
-    Records is_template, public, draft and from_template fields that already
-    exist on the Assembly table in production. Uses SeparateDatabaseAndState so
-    no DDL is executed against an existing database, but the test runner (which
-    builds from scratch) will create the columns correctly.
+    Adds is_template and from_template fields to Assembly.
+    Uses IF NOT EXISTS in the SQL so it is safe to run against a production
+    database where these columns may already exist, while still creating them
+    correctly on a fresh database.
     """
 
     dependencies = [
@@ -16,21 +15,48 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='assembly',
-            name='is_template',
-            field=models.BooleanField(default=False, help_text='Whether this assembly can be reused as a template'),
-        ),
-        migrations.AddField(
-            model_name='assembly',
-            name='from_template',
-            field=models.ForeignKey(
-                blank=True,
-                help_text='Original template this was created from',
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name='derived_assemblies',
-                to='pages.assembly',
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE pages_assembly
+                        ADD COLUMN IF NOT EXISTS is_template boolean NOT NULL DEFAULT false;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE pages_assembly DROP COLUMN IF EXISTS is_template;
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE pages_assembly
+                        ADD COLUMN IF NOT EXISTS from_template_id integer
+                            REFERENCES pages_assembly(id)
+                            ON DELETE SET NULL
+                            DEFERRABLE INITIALLY DEFERRED;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE pages_assembly DROP COLUMN IF EXISTS from_template_id;
+                    """,
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name='assembly',
+                    name='is_template',
+                    field=models.BooleanField(default=False, help_text='Whether this assembly can be reused as a template'),
+                ),
+                migrations.AddField(
+                    model_name='assembly',
+                    name='from_template',
+                    field=models.ForeignKey(
+                        blank=True,
+                        help_text='Original template this was created from',
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name='derived_assemblies',
+                        to='pages.assembly',
+                    ),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary

  adds the full buildings API surface needed by the BEAT admin tool frontend. all endpoints live under `/api/buildings/` and require JWT admin authentication via
   the existing `IsAdminUser` permission class.

  **building listing & export**

  - `GET /api/buildings/` — paginated, filterable list of all buildings accessible to the requesting admin. superadmin sees every org-linked building; regular   
  admin sees only buildings in their orgs. supports `search`, `country`, `city`, `climate_zone`, `draft`, `organisation` query params
  - `GET /api/buildings/export/` — same filters, streams an `.xlsx` file with 18 columns including all three carbon metrics per building

  **building detail**

  - `GET /api/buildings/<uuid>/` — existing summary serializer (unchanged)
  - `GET /api/buildings/<uuid>/detail/` — rich detail matching the HTMX detail page: core fields + operational schedule + all five system types (cooling,        
  ventilation, lighting, lift/escalator, hot water) + operational products + structural assemblies with materials + carbon stats + chart data (embodied by       
  assembly, embodied by material, operational by system)

  **excel import (10 steps)**

  step-by-step endpoints that reuse all existing parse helpers and Django forms from the HTMX import views. the only difference is access control —
  `_buildings_queryset(request)` is used instead of `created_by=request.user` so org-scoped admins can import too. includes `organisation_id` on step 1 to link  
  the building on creation.

  steps: `import/name-location/` → `import/details/` → `import/operational-schedule/` → `import/cooling-systems/` → `import/ventilation-systems/` →
  `import/lighting-systems/` → `import/lift-escalator/` → `import/hot-water-systems/` → `import/energy-carriers/` → `import/structural-components/` →
  `import/complete/`

  **manual add building (12 steps)**

  full CRUD endpoints for the multi-step form wizard. each system type supports individual create/update (POST) and delete (DELETE) so the frontend can add and  
  remove records one at a time without resubmitting the whole step.

  steps: `add/name-location/` → `add/details/` → `add/data/` (GET, restore) → `add/operational-schedule/` → `add/cooling-systems/` → `add/ventilation-systems/` →
   `add/lighting-systems/` → `add/lift-escalator/` → `add/hot-water-systems/` → `add/energy-carriers/` → `add/structural-components/` → `add/complete/`

  **migration fix**

  migration `0031_assembly_template_fields` was previously broken on production — it used `SeparateDatabaseAndState` with empty `database_operations`, which     
  means fresh databases never got the columns. replaced with `IF NOT EXISTS` SQL so it skips safely on production but still creates the columns correctly on a   
  fresh DB or in the test runner.