### PR TITLE
feat: implement full embodied & operational carbon calculation per PDF Spec

### DIFF
--- a/pages/migrations/0031_assembly_template_fields.py
+++ b/pages/migrations/0031_assembly_template_fields.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
                 migrations.RunSQL(
                     sql="""
                         ALTER TABLE pages_assembly
-                        ADD COLUMN IF NOT EXISTS from_template_id integer
+                        ADD COLUMN IF NOT EXISTS from_template_id uuid
                             REFERENCES pages_assembly(id)
                             ON DELETE SET NULL
                             DEFERRABLE INITIALLY DEFERRED;

--- a/pages/tests/test_impact_calculation.py
+++ b/pages/tests/test_impact_calculation.py
@@ -1,3 +1,15 @@
+"""
+Tests for calculate_impacts() — aligned with the PDF spec:
+  "Formula Reference — Embodied Carbon (A1–A3) Developer Edition"
+
+Conversion lookup uses 'name' key in EPD.conversions JSON:
+  - "volume density"          → kg/m³
+  - "area density"            → kg/m²
+  - "linear density"          → kg/m
+  - "conversion factor to 1 kg" → "-"
+
+Legacy data without 'name' key falls back to 'unit' string match.
+"""
 from decimal import Decimal
 
 import pytest
@@ -22,10 +34,13 @@ from pages.models.epd import (
     MaterialCategory,
     Unit,
 )
-from pages.views.building.impact_calculation import calculate_impacts
+from pages.views.building.impact_calculation import calculate_impacts, ImpactCalculationError
 
 
-# Fixtures for reusable components
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
 @pytest.fixture
 def create_impact():
     return Impact.objects.create(
@@ -45,7 +60,6 @@ def create_epd():
             declared_unit=declared_unit,
             conversions=conversions,
         )
-
     return _create_epd
 
 
@@ -57,7 +71,6 @@ def create_epd_impact(create_impact):
             impact=create_impact,
             value=value,
         )
-
     return _create_epd_impact
 
 
@@ -68,7 +81,6 @@ def create_assembly():
             mode=AssemblyMode.CUSTOM,
             dimension=dimension,
         )
-
     return _create_assembly
 
 
@@ -77,295 +89,463 @@ def create_product():
     def _create_product(assembly, epd, quantity, unit):
         category = AssemblyCategory.objects.first()
         technique = AssemblyTechnique.objects.first()
-
         assemblycategorytechnique, _ = AssemblyCategoryTechnique.objects.get_or_create(
             category=category,
             technique=technique,
             defaults={"description": "Created for test"},
         )
         return StructuralProduct.objects.create(
-            # Struct. Product
             assembly=assembly,
             classification=assemblycategorytechnique,
-            # Base product
             epd=epd,
             quantity=quantity,
             input_unit=unit,
         )
-
     return _create_product
 
 
-# Parametrized test with fixtures
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "epd_name, declared_unit, conversions, epdimpact_value, product_quantity, product_unit, expected_impact",
-    [
-        ( # From Excel: 2024-12-18 - LCA modelling - phase II - with macro.xlsm
-            "Cement screed",                        # epd_name
-            Unit.KG,                                # declared_unit
-            [{"unit": "kg/m^3", "value": "2200"}],  # conversions
-            Decimal("0.183550838458225"),           # epdimpact value
-            Decimal("3.5"),                         # product_value
-            Unit.CM,                                # product unit                          # assembly_quantity
-            Decimal("14.1334145612833"),            # expected impact
-        ),
-        ( # From Excel `2024-12-18 - LCA modelling - phase II - with macro.xlsm`
-            "PE foil, dimpled",
-            Unit.M2,
-            [{"unit": "kg/m^3", "value": "100"}],  # is not supposed to matter
-            Decimal("4.12"),
-            Decimal("1"),
-            Unit.UNKNOWN,
-            Decimal("4.12"),
-        ),
-        ( # Ensure M2 conversions doesn't matter for result
-            "PE foil, dimpled",
-            Unit.M2,
-            [],
-            Decimal("4.12"),
-            Decimal("1"),
-            Unit.UNKNOWN,
-            Decimal("4.12"),
-        ),
-        ( # From Excel `2024-12-18 - LCA modelling - phase II - with macro.xlsm`
-            "Extruded Polystrene (XPS)",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "32"}],
-            Decimal("94.0282964318439"),
-            Decimal("5"),
-            Unit.CM,
-            Decimal("4.70141482159219"),
-        ),
-        ( # Ensure M3 conversion doesn't matter for result
-            "Extruded Polystrene (XPS)",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "100"}],
-            Decimal("94.0282964318439"),
-            Decimal("5"),
-            Unit.CM,
-            Decimal("4.70141482159219"),
-        ),
-    ],
-)
-def test_calculate_impacts_area_assembly_benchmark(
-    epd_name,
-    declared_unit,
-    conversions,
-    epdimpact_value,
-    product_quantity,
-    product_unit,
-    expected_impact,
-    ### Functions
-    create_impact,
-    create_epd,
-    create_epd_impact,
-    create_assembly,
-    create_product,
-):
-    """Test if calculate impact matches Excel calculation of area assembly.
-    
-    Note:
-     - Excel comparison implies `reporting_life_cycle=1` and `assembly_quantity=1`
+# ---------------------------------------------------------------------------
+# Helper: run calculate_impacts with assembly_quantity=1, floor_area=1
+# ---------------------------------------------------------------------------
 
-    ARRANGE: Create simple Ökobaudat EPD and set to product from Excel with an area assembly.
-    ACT: Calculate impact of product
-    ASSERT: Matches expected values from Excel
-    """
-
-    # Arrange: Set up test data
-    impact = create_impact
-    epd = create_epd(epd_name, declared_unit, conversions)
-    create_epd_impact(epd, epdimpact_value)
-    assembly = create_assembly(dimension=AssemblyDimension.AREA)
-    product = create_product(assembly, epd, product_quantity, product_unit)
-
-    # Act: Perform the calculation
-    impacts = calculate_impacts(
-        dimension=assembly.dimension,
+def _calc(dimension, p):
+    return calculate_impacts(
+        dimension=dimension,
         assembly_quantity=1,
         total_floor_area=1,
-        p=product,
+        p=p,
     )
 
-    # Assert: Verify the results
-    assert len(impacts) == 1
-    for impact in impacts:
-        assert impact["impact_type"].__str__() == "gwp a1a3"
-        assert isinstance(impact["impact_value"], Decimal)
-        assert impact["impact_value"] == pytest.approx(
-            expected_impact, rel=Decimal("1e-15")
-        )
+
+def _gwp(impacts):
+    """Extract the single GWP A1-A3 impact value."""
+    for i in impacts:
+        if i["impact_type"].__str__() == "gwp a1a3":
+            return i["impact_value"]
+    raise AssertionError("No gwp a1a3 impact found")
 
 
-# Parametrized test with fixtures
+# ---------------------------------------------------------------------------
+# PDF Level 1 — Single material, direct matches (Step 2)
+# ---------------------------------------------------------------------------
+
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "epd_name, declared_unit, conversions, epdimpact_value, product_quantity, product_unit, dimension, expected_impact",
-    [
-        ( # Ensure kg/m^3 is used for KG conversion
-            "Test KG with M^2 & M^3",                                                   # epd_name
-            Unit.KG,                                                                    # declared_unit
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m^2", "value": "300"}],     # conversions
-            Decimal("3"),                                                               # epdimpact value
-            Decimal("4"),                                                               # product_quantity
-            Unit.CM,                                                                    # product unit  
-            AssemblyDimension.AREA,                                                     # dimension
-            Decimal("0.24"),   # 3 * 4 * 2 / 100                                        # expected impact
-        ),
-        ( # Ensure kg/m^3 is prioritized for KG conversion
-            "Test KG with M & M^3",
-            Unit.KG,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.CM2,
-            AssemblyDimension.LENGTH,
-            Decimal("0.0024"),  # 3 * 4 * 2 / 1000
-        ),
-        ( # Ensure KG fallback to m^3 works
-            "Test KG with M^3",
-            Unit.KG,
-            [{"unit": "kg/m^3", "value": "2"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.CM2,
-            AssemblyDimension.LENGTH,
-            Decimal("0.0024"),  # 3 * 4 * 2 / 1000
-        ),
-        ( # Ensure M3 conversion for Volume Dimension
-            "Test M3 for Mass",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m^2", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.PERCENT,
-            AssemblyDimension.MASS,
-            Decimal("0.06"),  # 3 * 4 / 2 / 100 (because percent)
-        ),
-        ( # Ensure for PCS Dimension
-            "Test PCS",
-            Unit.PCS,
-            [{"unit": "kg/m^3", "value": "8"}, {"unit": "kg/m^2", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.PCS,
-            AssemblyDimension.MASS,
-            Decimal("12"),  # 3 * 4
-        ),
-    ],
-)
-def test_calculate_impacts_dimension_logic(
-    epd_name,
-    declared_unit,
-    conversions,
-    epdimpact_value,
-    product_quantity,
-    product_unit,
-    dimension,
-    expected_impact,
-    ### Functions
-    create_impact,
-    create_epd,
-    create_epd_impact,
-    create_assembly,
-    create_product,
-):
-    """Test if calculate impact satisfies dimension logic.
-    
-    # Note:
-     - KG needs special consideration since these are scaled
+def test_area_m2_direct(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area assembly + EPD m² → Factor = assembly_quantity × layer_count."""
+    epd = create_epd("Slab", Unit.M2, [])
+    create_epd_impact(epd, Decimal("4.12"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("1"), Unit.UNKNOWN)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("4.12"))
 
-    ARRANGE: Create simple EPD and set dimension of assembly.
-    ACT: Calculate impact of product.
-    ASSERT: Matches expected value.
+
+@pytest.mark.django_db
+def test_volume_m3_direct(create_epd, create_epd_impact, create_assembly, create_product):
+    """Volume assembly + EPD m³ → Factor = assembly_quantity × share."""
+    epd = create_epd("Concrete", Unit.M3, [])
+    create_epd_impact(epd, Decimal("300"))
+    assembly = create_assembly(AssemblyDimension.VOLUME)
+    p = create_product(assembly, epd, Decimal("50"), Unit.PERCENT)  # 50% share
+    # Factor = 1 * 0.50 = 0.5  →  impact = 300 * 0.5 = 150
+    assert _gwp(_calc(AssemblyDimension.VOLUME, p)) == pytest.approx(Decimal("150"))
+
+
+@pytest.mark.django_db
+def test_mass_kg_direct(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass assembly + EPD kg → Factor = assembly_quantity × share_of_mass."""
+    epd = create_epd("Cement", Unit.KG, [])
+    create_epd_impact(epd, Decimal("0.82"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    p = create_product(assembly, epd, Decimal("100"), Unit.PERCENT)  # 100% share
+    # Factor = 1 * 1.00 = 1  →  impact = 0.82
+    assert _gwp(_calc(AssemblyDimension.MASS, p)) == pytest.approx(Decimal("0.82"))
+
+
+@pytest.mark.django_db
+def test_length_m_direct(create_epd, create_epd_impact, create_assembly, create_product):
+    """Length assembly + EPD m → Factor = assembly_quantity × count."""
+    epd = create_epd("Pipe", Unit.M, [])
+    create_epd_impact(epd, Decimal("5"))
+    assembly = create_assembly(AssemblyDimension.LENGTH)
+    p = create_product(assembly, epd, Decimal("3"), Unit.UNKNOWN)
+    # Factor = 1 * 3 = 3  →  impact = 15
+    assert _gwp(_calc(AssemblyDimension.LENGTH, p)) == pytest.approx(Decimal("15"))
+
+
+@pytest.mark.django_db
+def test_pcs_any_dimension(create_epd, create_epd_impact, create_assembly, create_product):
+    """pcs EPD: Factor = product_quantity, assembly_quantity ignored."""
+    epd = create_epd("Tile", Unit.PCS, [])
+    create_epd_impact(epd, Decimal("0.045"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("25"), Unit.PCS)
+    # Factor = 25  →  impact = 0.045 * 25 = 1.125
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("1.125"))
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 1 — Area assembly conversions (Step 3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_area_m3_via_thickness(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area → m³: Factor = assembly_qty × thickness_m.
+    thickness = 5 cm → 0.05 m.  EPD impact = 94.  Factor = 1 * 0.05 = 0.05.  Result = 4.7.
+    From Excel benchmark.
     """
-
-    # Arrange: Set up test data
-    impact = create_impact
-    epd = create_epd(epd_name, declared_unit, conversions)
-    create_epd_impact(epd, epdimpact_value)
-    assembly = create_assembly(dimension=dimension)
-    product = create_product(assembly, epd, product_quantity, product_unit)
-
-    # Act: Perform the calculation
-    impacts = calculate_impacts(
-        dimension=assembly.dimension,
-        assembly_quantity=1,
-        total_floor_area=1,
-        p=product,
+    epd = create_epd("XPS", Unit.M3, [{"name": "volume density", "value": "32", "unit": "kg/m^3"}])
+    create_epd_impact(epd, Decimal("94.0282964318439"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(
+        Decimal("4.70141482159219"), rel=Decimal("1e-10")
     )
 
-    # Assert: Verify the results
-    assert len(impacts) == 1
-    for impact in impacts:
-        assert impact["impact_type"].__str__() == "gwp a1a3"
-        assert isinstance(impact["impact_value"], Decimal)
-        assert impact["impact_value"] == pytest.approx(
-            expected_impact, rel=Decimal("1e-15")
-        )
+
+@pytest.mark.django_db
+def test_area_kg_via_area_density_preferred(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area → kg: Option B (preferred) — area density.
+    Factor = assembly_qty × area_density = 1 × 12 = 12.  impact = 0.1 * 12 = 1.2.
+    """
+    epd = create_epd("Paint", Unit.KG, [
+        {"name": "area density", "value": "12", "unit": "kg/m^2"},
+        {"name": "volume density", "value": "1200", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("0.1"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    # quantity/input_unit here is irrelevant when area density exists
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("1.2"))
 
 
-# Parametrized test with fixtures
+@pytest.mark.django_db
+def test_area_kg_via_thickness_volume_density_fallback(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area → kg: Option A (fallback) — thickness × volume density (no area density).
+    thickness=3.5 cm → 0.035 m.  volume_density=2200.  Factor=1×0.035×2200=77.
+    impact = 0.183550838458225 × 77 = 14.1334...  (Excel benchmark)
+    """
+    epd = create_epd("Cement screed", Unit.KG, [
+        {"name": "volume density", "value": "2200", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("0.183550838458225"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("3.5"), Unit.CM)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(
+        Decimal("14.1334145612833"), rel=Decimal("1e-10")
+    )
+
+
+@pytest.mark.django_db
+def test_area_kg_via_conversion_factor_last_resort(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area → kg: Option C (last resort) — conversion factor to 1 kg.
+    Factor = assembly_qty × conv_factor = 1 × 5 = 5.  impact = 2 * 5 = 10.
+    """
+    epd = create_epd("Material C", Unit.KG, [
+        {"name": "conversion factor to 1 kg", "value": "5", "unit": "-"},
+    ])
+    create_epd_impact(epd, Decimal("2"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("10"))
+
+
+@pytest.mark.django_db
+def test_area_kg_blocks_when_no_conversion(create_epd, create_epd_impact, create_assembly, create_product):
+    """Area → kg: BLOCK when no area density, volume density, or conversion factor."""
+    epd = create_epd("Mystery", Unit.KG, [])
+    create_epd_impact(epd, Decimal("1"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    with pytest.raises(ImpactCalculationError):
+        _calc(AssemblyDimension.AREA, p)
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 1 — Volume assembly conversions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_volume_kg_via_volume_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Volume → kg: Factor = assembly_qty × share × volume_density.
+    share=50%→0.5.  volume_density=2.  Factor=1×0.5×2=1.  impact=3.
+    """
+    epd = create_epd("Concrete vol", Unit.KG, [
+        {"name": "volume density", "value": "2", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.VOLUME)
+    p = create_product(assembly, epd, Decimal("50"), Unit.PERCENT)
+    assert _gwp(_calc(AssemblyDimension.VOLUME, p)) == pytest.approx(Decimal("3"))
+
+
+@pytest.mark.django_db
+def test_volume_kg_via_conv_factor_fallback(create_epd, create_epd_impact, create_assembly, create_product):
+    """Volume → kg: fallback to conversion factor to 1 kg when no volume density."""
+    epd = create_epd("Vol mat", Unit.KG, [
+        {"name": "conversion factor to 1 kg", "value": "4", "unit": "-"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.VOLUME)
+    p = create_product(assembly, epd, Decimal("50"), Unit.PERCENT)
+    # Factor = 1 × 0.5 × 4 = 2  →  impact = 6
+    assert _gwp(_calc(AssemblyDimension.VOLUME, p)) == pytest.approx(Decimal("6"))
+
+
+@pytest.mark.django_db
+def test_volume_kg_blocks_no_conversion(create_epd, create_epd_impact, create_assembly, create_product):
+    """Volume → kg: BLOCK when no volume density or conversion factor."""
+    epd = create_epd("Vol mystery", Unit.KG, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.VOLUME)
+    p = create_product(assembly, epd, Decimal("50"), Unit.PERCENT)
+    with pytest.raises(ImpactCalculationError):
+        _calc(AssemblyDimension.VOLUME, p)
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 1 — Mass assembly conversions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_mass_m3_via_volume_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass → m³: Factor = constituent_mass / volume_density.
+    share=100%→1.0 (single constituent).  volume_density=2.
+    Factor = 1 × 1.0 / 2 = 0.5.  impact = 3 × 0.5 = 1.5.
+    """
+    epd = create_epd("Dense mat", Unit.M3, [
+        {"name": "volume density", "value": "2", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    # 100% share — single constituent, validates correctly
+    p = create_product(assembly, epd, Decimal("100"), Unit.PERCENT)
+    assert _gwp(_calc(AssemblyDimension.MASS, p)) == pytest.approx(Decimal("1.5"))
+
+
+@pytest.mark.django_db
+def test_mass_m3_blocks_no_volume_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass → m³: BLOCK — no fallback allowed per PDF spec."""
+    epd = create_epd("No density", Unit.M3, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    p = create_product(assembly, epd, Decimal("4"), Unit.PERCENT)
+    with pytest.raises(ImpactCalculationError):
+        _calc(AssemblyDimension.MASS, p)
+
+
+@pytest.mark.django_db
+def test_mass_m2_via_area_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass → m²: Factor = constituent_mass / area_density.
+    share=100%→1.0 kg (single constituent).  area_density=10.
+    Factor = 1 × 1.0 / 10 = 0.1.  impact = 2 × 0.1 = 0.2.
+    """
+    epd = create_epd("Sheet", Unit.M2, [
+        {"name": "area density", "value": "10", "unit": "kg/m^2"},
+    ])
+    create_epd_impact(epd, Decimal("2"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    # 100% share — single constituent, validates correctly
+    p = create_product(assembly, epd, Decimal("100"), Unit.PERCENT)
+    assert _gwp(_calc(AssemblyDimension.MASS, p)) == pytest.approx(Decimal("0.2"))
+
+
+@pytest.mark.django_db
+def test_mass_m2_blocks_no_area_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass → m²: BLOCK — no fallback allowed per PDF spec."""
+    epd = create_epd("No area density", Unit.M2, [])
+    create_epd_impact(epd, Decimal("2"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    p = create_product(assembly, epd, Decimal("50"), Unit.PERCENT)
+    with pytest.raises(ImpactCalculationError):
+        _calc(AssemblyDimension.MASS, p)
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 1 — Length assembly conversions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_length_m3_via_cross_section(create_epd, create_epd_impact, create_assembly, create_product):
+    """Length → m³: Factor = assembly_qty × cross_section_m².
+    cross_section=100 cm² → 0.01 m².  Factor=1×0.01=0.01.  impact=3×0.01=0.03.
+    """
+    epd = create_epd("Beam", Unit.M3, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.LENGTH)
+    p = create_product(assembly, epd, Decimal("100"), Unit.CM2)
+    assert _gwp(_calc(AssemblyDimension.LENGTH, p)) == pytest.approx(Decimal("0.03"))
+
+
+@pytest.mark.django_db
+def test_length_kg_via_linear_density_preferred(create_epd, create_epd_impact, create_assembly, create_product):
+    """Length → kg: Option A (preferred) — linear density.
+    Factor = assembly_qty × linear_density = 1 × 7.85 = 7.85.  impact = 2 × 7.85 = 15.7.
+    """
+    epd = create_epd("Steel bar", Unit.KG, [
+        {"name": "linear density", "value": "7.85", "unit": "kg/m"},
+        {"name": "volume density", "value": "7850", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("2"))
+    assembly = create_assembly(AssemblyDimension.LENGTH)
+    p = create_product(assembly, epd, Decimal("100"), Unit.CM2)
+    assert _gwp(_calc(AssemblyDimension.LENGTH, p)) == pytest.approx(Decimal("15.7"))
+
+
+@pytest.mark.django_db
+def test_length_kg_via_cross_section_volume_density_fallback(create_epd, create_epd_impact, create_assembly, create_product):
+    """Length → kg: Option B (fallback) — cross_section × volume_density (no linear density).
+    cross_section=100 cm² → 0.01 m².  volume_density=2.  Factor=1×0.01×2=0.02.  impact=3×0.02=0.06.
+    """
+    epd = create_epd("Beam KG", Unit.KG, [
+        {"name": "volume density", "value": "2", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.LENGTH)
+    p = create_product(assembly, epd, Decimal("100"), Unit.CM2)
+    assert _gwp(_calc(AssemblyDimension.LENGTH, p)) == pytest.approx(Decimal("0.06"))
+
+
+@pytest.mark.django_db
+def test_length_kg_blocks_no_conversion(create_epd, create_epd_impact, create_assembly, create_product):
+    """Length → kg: BLOCK when no linear density and no volume density.
+    CM2 unit is valid for LENGTH+KG (cross-section). But without volume density,
+    the cross_section path also fails → ImpactCalculationError.
+    """
+    epd = create_epd("Mystery length", Unit.KG, [
+        # Has kg/m^3 so model validation (epd_filtering) passes,
+        # but we strip it to simulate the no-conversion case by patching conversions
+        {"name": "volume density", "value": "5", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_assembly(AssemblyDimension.LENGTH)
+    p = create_product(assembly, epd, Decimal("100"), Unit.CM2)
+    # Now clear conversions at runtime to simulate missing data
+    p.epd.conversions = []
+    with pytest.raises(ImpactCalculationError):
+        _calc(AssemblyDimension.LENGTH, p)
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 1 — _resolve_thickness_m: derive from EPD conversions when no user thickness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_resolve_thickness_from_epd_conversions(create_epd, create_epd_impact, create_assembly, create_product):
+    """_resolve_thickness_m: derive thickness = area_density / volume_density when input_unit != cm.
+    area_density=24, volume_density=1200 → thickness = 24/1200 = 0.02 m.
+    Area→m³ with CM input_unit=0 (we set quantity=0 to force EPD-derived path):
+    Actually: use a product saved with CM unit but then override input_unit at runtime
+    so _resolve_thickness_m skips the user-entered path and derives from EPD.
+
+    Simpler: just verify that when BOTH area+volume density exist, thickness is derived.
+    Use quantity=0 with CM so the cm path returns 0.0 which would be wrong — instead
+    patch input_unit to UNKNOWN at runtime after creation (model already saved).
+    area_density=24 / volume_density=1200 = 0.02 m.  Factor=1×0.02=0.02.  impact=5×0.02=0.1.
+    """
+    epd = create_epd("Derived thickness", Unit.M3, [
+        {"name": "area density", "value": "24", "unit": "kg/m^2"},
+        {"name": "volume density", "value": "1200", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("5"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    # Save with CM (valid for AREA+M3), then override input_unit to UNKNOWN at runtime
+    # so _resolve_thickness_m falls through to the EPD-derived path
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    p.input_unit = Unit.UNKNOWN  # override without re-saving — bypasses clean()
+    # Now thickness_m must be derived: 24 / 1200 = 0.02 m
+    # Factor = 1 × 0.02 = 0.02,  impact = 5 × 0.02 = 0.1
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("0.1"))
+
+
+# ---------------------------------------------------------------------------
+# PDF Level 2 — Composite validation: share_of_mass must sum to 100%
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_mass_share_sum_validation(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass assembly: shares not summing to 100% must raise ImpactCalculationError."""
+    epd1 = create_epd("Mat A", Unit.KG, [])
+    epd2 = create_epd("Mat B", Unit.KG, [])
+    create_epd_impact(epd1, Decimal("1"))
+    create_epd_impact(epd2, Decimal("1"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    p1 = create_product(assembly, epd1, Decimal("60"), Unit.PERCENT)
+    p2 = create_product(assembly, epd2, Decimal("30"), Unit.PERCENT)  # total=90%, not 100%
+
+    with pytest.raises(ImpactCalculationError, match="100%"):
+        _calc(AssemblyDimension.MASS, p1)
+
+
+@pytest.mark.django_db
+def test_mass_share_sum_100_passes(create_epd, create_epd_impact, create_assembly, create_product):
+    """Mass assembly: shares summing to exactly 100% must not raise."""
+    epd1 = create_epd("Mat X", Unit.KG, [])
+    epd2 = create_epd("Mat Y", Unit.KG, [])
+    create_epd_impact(epd1, Decimal("0.5"))
+    create_epd_impact(epd2, Decimal("0.5"))
+    assembly = create_assembly(AssemblyDimension.MASS)
+    p1 = create_product(assembly, epd1, Decimal("70"), Unit.PERCENT)
+    p2 = create_product(assembly, epd2, Decimal("30"), Unit.PERCENT)
+    # Should not raise; just check it returns a result
+    result = _calc(AssemblyDimension.MASS, p1)
+    assert len(result) >= 1
+
+
+# ---------------------------------------------------------------------------
+# PDF — Legacy data: fallback to 'unit' string match (no 'name' key)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_legacy_unit_string_fallback_volume_density(create_epd, create_epd_impact, create_assembly, create_product):
+    """Legacy EPD data without 'name' key: volume density matched by unit string 'kg/m^3'."""
+    epd = create_epd("Legacy cement", Unit.KG, [
+        {"unit": "kg/m^3", "value": "2200"},  # no 'name' key
+    ])
+    create_epd_impact(epd, Decimal("0.183550838458225"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("3.5"), Unit.CM)
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(
+        Decimal("14.1334145612833"), rel=Decimal("1e-10")
+    )
+
+
+@pytest.mark.django_db
+def test_legacy_unit_string_area_density_preferred(create_epd, create_epd_impact, create_assembly, create_product):
+    """Legacy EPD: area density (kg/m^2) preferred over volume density (kg/m^3) for Area→kg."""
+    epd = create_epd("Legacy paint", Unit.KG, [
+        {"unit": "kg/m^2", "value": "12"},   # area density — preferred
+        {"unit": "kg/m^3", "value": "1200"},  # volume density — fallback
+    ])
+    create_epd_impact(epd, Decimal("0.1"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    # Must use area density: Factor = 1 × 12 = 12  →  impact = 1.2
+    assert _gwp(_calc(AssemblyDimension.AREA, p)) == pytest.approx(Decimal("1.2"))
+
+
+# ---------------------------------------------------------------------------
+# Model validation: StructuralProduct.clean() rejects invalid unit combos
+# ---------------------------------------------------------------------------
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "epd_name, declared_unit, conversions, epdimpact_value, product_quantity, product_unit, dimension",
+    "declared_unit, conversions, quantity, product_unit, dimension",
     [
-        ( # Ensure KG conversion for Volume Dimension
-            #TODO changed dimension to KG
-            "Test M3 for Mass",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m^2", "value": "20"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.CM,
-            AssemblyDimension.MASS,
-        ),
-        ( # Ensure KG fallback to m works
-            "Test KG with M",
-            Unit.KG,
-            [{"unit": "kg/m", "value": "2"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.UNKNOWN,
-            AssemblyDimension.LENGTH,
-        ),
-        ( # Ensure KG fallback to m^2 works
-            "Test KG with M^2",
-            Unit.KG,
-            [{"unit": "kg/m^2", "value": "2"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.UNKNOWN,
-            AssemblyDimension.AREA,
-        ),
+        # Mass assembly + m3 EPD without volume density → invalid unit at model level
+        (Unit.M3, [], Decimal("4"), Unit.CM, AssemblyDimension.MASS),
+        # Length assembly + kg EPD without any conversion → UNKNOWN unit invalid
+        (Unit.KG, [], Decimal("4"), Unit.UNKNOWN, AssemblyDimension.LENGTH),
+        # Area assembly + kg EPD without any conversion → UNKNOWN unit invalid
+        (Unit.KG, [], Decimal("4"), Unit.UNKNOWN, AssemblyDimension.AREA),
     ],
 )
-def test_calculate_impacts_errors(
-    epd_name,
-    declared_unit,
-    conversions,
-    epdimpact_value,
-    product_quantity,
-    product_unit,
-    dimension,
-    ### Functions
-    create_epd,
-    create_epd_impact,
-    create_assembly,
-    create_product,
+def test_model_validation_rejects_invalid_units(
+    declared_unit, conversions, quantity, product_unit, dimension,
+    create_epd, create_epd_impact, create_assembly, create_product,
 ):
-    """Test if calculate impact satisfies dimension logic.
-
-    ARRANGE: Create simple EPD and set dimension of assembly.
-    ACT: Create product.
-    ASSERT: Raises validation error.
-    """
-
-    # Arrange: Set up test data
-    epd = create_epd(epd_name, declared_unit, conversions)
-    create_epd_impact(epd, epdimpact_value)
+    """StructuralProduct.clean() raises ValidationError for invalid unit combinations."""
+    epd = create_epd("Test", declared_unit, conversions)
+    create_epd_impact(epd, Decimal("3"))
     assembly = create_assembly(dimension=dimension)
-    
     with pytest.raises(ValidationError):
-        create_product(assembly, epd, product_quantity, product_unit)
+        create_product(assembly, epd, quantity, product_unit)

--- a/pages/tests/test_impact_calculation_boq.py
+++ b/pages/tests/test_impact_calculation_boq.py
@@ -1,11 +1,16 @@
+"""
+Tests for calculate_impacts() with BoQ assemblies.
+
+In BoQ assemblies (is_boq=True), the assembly-level dimension is ignored.
+Dimension is inferred from the product's input_unit instead.
+"""
 from decimal import Decimal
 
 import pytest
-from django.core.exceptions import ValidationError
 
 from pages.models.epd import Unit
 from pages.models.assembly import Assembly, AssemblyMode, AssemblyDimension
-from pages.views.building.impact_calculation import calculate_impacts
+from pages.views.building.impact_calculation import calculate_impacts, ImpactCalculationError
 
 from pages.tests.test_impact_calculation import (
     create_epd,
@@ -21,165 +26,119 @@ def create_boq_assembly():
     def _create_assembly():
         return Assembly.objects.create(
             mode=AssemblyMode.CUSTOM,
-            dimension=AssemblyDimension.AREA,
-            is_boq=True
+            dimension=AssemblyDimension.AREA,  # irrelevant for BoQ
+            is_boq=True,
         )
-
     return _create_assembly
 
 
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "epd_name, declared_unit, conversions, epdimpact_value, product_quantity, product_unit, expected_impact",
-    [
-        ( # Test Pieces
-            "Test PCS",                                  # epd_name
-            Unit.PCS,                                    # declared_unit
-            [],                                          # conversions
-            Decimal("3"),                                # epdimpact value
-            Decimal("4"),                                # product_quantity
-            Unit.PCS,                                    # product unit  
-            Decimal("12"),   # 3 * 4                     # expected impact
-        ),
-        ( # Test M
-            "Test M",
-            Unit.M,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.M,
-            Decimal("12"),  # 3 * 4
-        ),
-        ( # Test M2
-            "Test M2",
-            Unit.M2,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.M2,
-            Decimal("12"),  # 3 * 4
-        ),
-        ( # Test M3
-            "Test M3",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.M3,
-            Decimal("12"),  # 3 * 4
-        ),
-        ( # Test KG
-            "Test KG",
-            Unit.KG,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m", "value": "300"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.KG,
-            Decimal("12"),  # 3 * 4
-        ),
-    ],
-)
-def test_calculate_impacts_boq(
-    epd_name,
-    declared_unit,
-    conversions,
-    epdimpact_value,
-    product_quantity,
-    product_unit,
-    expected_impact,
-    ### Functions
-    create_impact,
-    create_epd,
-    create_epd_impact,
-    create_boq_assembly,
-    create_product,
-):
-    """Test if calculate impact works for BoQs.
-    
-    In BoQs the assembly Dimension plays no role. Currently conversions are not touched.
-
-    ARRANGE: Create simple EPD and Product for an assembly with is_boq=True
-    ACT: Calculate impact of product.
-    ASSERT: Matches expected values.
-    """
-    #TODO if conversions are used for BoQs, extend test.
-    # Arrange: Set up test data
-    impact = create_impact
-    epd = create_epd(epd_name, declared_unit, conversions)
-    create_epd_impact(epd, epdimpact_value)
-    assembly = create_boq_assembly()
-    product = create_product(assembly, epd, product_quantity, product_unit)
-
-    # Act: Perform the calculation
-    impacts = calculate_impacts(
+def _calc_boq(p):
+    """Run calculate_impacts for a BoQ product (dimension=None, assembly_quantity=1, floor_area=1)."""
+    return calculate_impacts(
         dimension=None,
         assembly_quantity=1,
         total_floor_area=1,
-        p=product,
+        p=p,
     )
 
-    # Assert: Verify the results
-    assert len(impacts) == 1
-    for impact in impacts:
-        assert impact["impact_type"].__str__() == "gwp a1a3"
-        assert isinstance(impact["impact_value"], Decimal)
-        assert impact["impact_value"] == pytest.approx(
-            expected_impact, rel=Decimal("1e-15")
-        )
+
+def _gwp(impacts):
+    for i in impacts:
+        if i["impact_type"].__str__() == "gwp a1a3":
+            return i["impact_value"]
+    raise AssertionError("No gwp a1a3 impact found")
 
 
+# ---------------------------------------------------------------------------
+# BoQ: direct unit matches — dimension inferred from input_unit
+# ---------------------------------------------------------------------------
 
-# Parametrized test with fixtures
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "epd_name, declared_unit, conversions, epdimpact_value, product_quantity, product_unit",
-    [
-        ( # conversions are not used
-            "Test M3",
-            Unit.M3,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m^2", "value": "20"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.KG,
-        ),
-        ( # conversions are not used
-            "Test KG",
-            Unit.KG,
-            [{"unit": "kg/m^3", "value": "2"}, {"unit": "kg/m^2", "value": "20"}],
-            Decimal("3"),
-            Decimal("4"),
-            Unit.M3,
-        ),
-    ],
-)
-def test_calculate_impacts_boq_errors(
-    epd_name,
-    declared_unit,
-    conversions,
-    epdimpact_value,
-    product_quantity,
-    product_unit,
-    ### Functions
-    create_epd,
-    create_epd_impact,
-    create_boq_assembly,
-    create_product,
-):
-    """Test if calculate impact satisfies dimension logic.
-    
-    Note
-     - currently BoQs do not use conversions.
-
-    ARRANGE: Create simple EPD and set input unit for matching conversion.
-    ACT: Create product.
-    ASSERT: Raises validation error.
-    """
-
-    # Arrange: Set up test data
-    epd = create_epd(epd_name, declared_unit, conversions)
-    create_epd_impact(epd, epdimpact_value)
+def test_boq_pcs(create_epd, create_epd_impact, create_boq_assembly, create_product):
+    """BoQ + pcs EPD → Factor = product_quantity."""
+    epd = create_epd("Tile", Unit.PCS, [])
+    create_epd_impact(epd, Decimal("3"))
     assembly = create_boq_assembly()
-    
-    product = create_product(assembly, epd, product_quantity, product_unit)
-    
-    assert product is not None
+    p = create_product(assembly, epd, Decimal("4"), Unit.PCS)
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("12"))
+
+
+@pytest.mark.django_db
+def test_boq_m(create_epd, create_epd_impact, create_boq_assembly, create_product):
+    """BoQ + m EPD with input_unit=m → direct match, Factor = 1 × 4 = 4."""
+    epd = create_epd("Pipe", Unit.M, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    p = create_product(assembly, epd, Decimal("4"), Unit.M)
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("12"))
+
+
+@pytest.mark.django_db
+def test_boq_m2(create_epd, create_epd_impact, create_boq_assembly, create_product):
+    """BoQ + m² EPD with input_unit=m2 → direct match, Factor = 1 × 4 = 4."""
+    epd = create_epd("Slab", Unit.M2, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    p = create_product(assembly, epd, Decimal("4"), Unit.M2)
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("12"))
+
+
+@pytest.mark.django_db
+def test_boq_m3(create_epd, create_epd_impact, create_boq_assembly, create_product):
+    """BoQ + m³ EPD with input_unit=m3 → direct match, Factor = 1 × 4 = 4."""
+    epd = create_epd("Concrete", Unit.M3, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    p = create_product(assembly, epd, Decimal("4"), Unit.M3)
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("12"))
+
+
+@pytest.mark.django_db
+def test_boq_kg(create_epd, create_epd_impact, create_boq_assembly, create_product):
+    """BoQ + kg EPD with input_unit=kg → direct match, Factor = 1 × 4 = 4."""
+    epd = create_epd("Steel", Unit.KG, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    p = create_product(assembly, epd, Decimal("4"), Unit.KG)
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("12"))
+
+
+# ---------------------------------------------------------------------------
+# BoQ: conversions used when input_unit ≠ declared_unit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_boq_kg_epd_with_m3_input_uses_volume_density(
+    create_epd, create_epd_impact, create_boq_assembly, create_product
+):
+    """BoQ + kg EPD but input_unit=m3 → inferred VOLUME dimension.
+    Volume→kg: Factor = assembly_qty × share × volume_density.
+    product_quantity stored as m3 directly (not percent for BoQ).
+    Factor = 1 × 4 × 2 = 8  →  impact = 3 × 8 = 24.
+    """
+    epd = create_epd("BoQ Dense", Unit.KG, [
+        {"name": "volume density", "value": "2", "unit": "kg/m^3"},
+    ])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    p = create_product(assembly, epd, Decimal("4"), Unit.M3)
+    # input_unit=M3 → dimension inferred as VOLUME
+    # Volume+KG: Factor = 1 × 4 × 2 = 8
+    assert _gwp(_calc_boq(p)) == pytest.approx(Decimal("24"))
+
+
+@pytest.mark.django_db
+def test_boq_m3_epd_with_kg_input_raises(
+    create_epd, create_epd_impact, create_boq_assembly, create_product
+):
+    """BoQ + m³ EPD with input_unit=kg → inferred MASS dimension.
+    Mass→m³ requires volume density. If missing, raise ImpactCalculationError.
+    """
+    epd = create_epd("BoQ No density", Unit.M3, [])
+    create_epd_impact(epd, Decimal("3"))
+    assembly = create_boq_assembly()
+    # Create with M3 (valid for M3 EPD), then override to KG at runtime
+    p = create_product(assembly, epd, Decimal("4"), Unit.M3)
+    p.input_unit = Unit.KG  # simulate KG input without re-triggering model validation
+    with pytest.raises(ImpactCalculationError):
+        _calc_boq(p)

--- a/pages/views/building/impact_calculation.py
+++ b/pages/views/building/impact_calculation.py
@@ -5,180 +5,346 @@ from pages.models.assembly import AssemblyDimension, StructuralProduct
 from pages.models.epd import Unit
 
 if TYPE_CHECKING:
-    # Use a forward reference to avoid circular import at runtime
     from pages.models.building import OperationalProduct
 
 
-# TODO: Add Try/Catch when trying to fetch a non-existing conversion and handle and display error
+class ImpactCalculationError(ValueError):
+    """Raised when a factor cannot be resolved due to missing EPD conversion data."""
+    pass
+
+
 def calculate_impacts(
     dimension: AssemblyDimension,
     assembly_quantity: int,
     total_floor_area: int,
     p: StructuralProduct,
 ):
-    """Calculate EPDs using the dimension approach.
+    """Calculate embodied carbon emissions using the Factor resolution logic from the PDF spec.
 
-    # Each AssembyDimension implies a set of allowed `declared_unit`s of EPDs. This is summarized
-    in the table below.
-    | **    Declared unit   ** | **    Area Assembly   ** | **    Volume Assembly   ** | **    Mass Assembly   ** | **    Length Assembly   ** |
-    |--------------------------|--------------------------|----------------------------|--------------------------|----------------------------|
-    |     m3                   |     Yes                  |     Yes                    |     w. Volume density    |     Yes                    |
-    |     m2                   |     Yes                  |     No                     |     No                   |     No                     |
-    |     m                    |     No                   |     No                     |     No                   |     Yes                    |
-    |     kg                   |     w. Volume density    |     w. Volume density      |     Yes                  |     w. Volume density      |
-    |     pieces               |     Set a quantity       |     Set a quantity         |     Set a quantity       |     Set a quantity         |
+    Formula:
+        Emissions [kgCO₂e] = Factor × (EPDImpact.value / EPD.declared_amount)
+        Emissions per m²   = Total Emissions / floor_area
 
-    # Notes
-     - Some EPDs do not have a base unit of 1 (e.g. 1 kg). That is why we normalize by 'declared_amount'
+    Factor resolution:
+        Step 1 — pcs check
+        Step 2 — direct unit match
+        Step 3 — conversion paths per assembly dimension
 
+    Field mapping (StructuralProduct.quantity + input_unit → PDF concept):
+        input_unit=cm       → thickness          (÷100 → metres)
+        input_unit=percent  → share_of_mass / share_of_volume
+        input_unit=cm2      → cross_section       (÷10000 → m²)
+        input_unit=pcs      → product_quantity    (pieces per assembly unit)
+        input_unit=unknown  → layer count (area/m² direct match)
+        input_unit=m/m2/m3/kg → BoQ direct quantity
     """
 
-    def fetch_conversion(unit: str) -> str | None:
-        """Fetch conversion factor based on the unit."""
+    # ------------------------------------------------------------------
+    # Helpers — EPD conversion lookup
+    # ------------------------------------------------------------------
+
+    def _epd_conversion(name: str) -> Decimal | None:
+        """Return a conversion value from EPD.conversions by name.
+
+        Lookup order:
+          1. Match by 'name' key (PDF spec: "volume density", "area density", etc.)
+          2. Fallback: match by 'unit' string for legacy data without 'name' key.
+        """
         try:
-            return next(
-                (c["value"] for c in p.epd.conversions if c["unit"] == unit), None
-            )
-        except:
+            conversions = p.epd.conversions or []
+            for c in conversions:
+                if c.get("name") == name:
+                    return Decimal(str(c["value"]))
+            # Legacy fallback: unit-string map
+            unit_map = {
+                "volume density": "kg/m^3",
+                "area density": "kg/m^2",
+                "linear density": "kg/m",
+                "conversion factor to 1 kg": "-",
+            }
+            unit_str = unit_map.get(name)
+            if unit_str:
+                for c in conversions:
+                    if c.get("unit") == unit_str:
+                        return Decimal(str(c["value"]))
+            return None
+        except Exception:
             return None
 
-    def fetch_dimension_for_boq(input_unit):
-        """Assign dimension based on 'input_unit'."""
-        boq_dim_map = {
-            Unit.PCS: None,  # pieces doesn't rely on dimension
-            Unit.M: AssemblyDimension.LENGTH,
-            Unit.M2: AssemblyDimension.AREA,
-            Unit.M3: AssemblyDimension.VOLUME,
-            Unit.KG: AssemblyDimension.MASS,
-        }
-        return boq_dim_map[input_unit]
+    def _resolve_thickness_m() -> Decimal:
+        """Resolve layer thickness in metres.
 
-    def calculate_impact(factor=1):
-        """Calculate impacts using a given factor and normalized by EPD base amount and reporting life_cycle."""
-        impacts_list = getattr(p.epd, "all_impacts", None)
-        if not impacts_list:
-            impacts_list = p.epd.epdimpact_set.all()
-        
-        container = []
-        for epdimpact in impacts_list:
-            container.append(
-                {
-                    "assembly_id": p.assembly.pk,
-                    "epd_id": p.epd.pk,
-                    "assembly_category": (
-                        p.classification.category if p.classification else ""
-                    ),
-                    "material_category": p.epd.category,
-                    "impact_type": epdimpact.impact,
-                    "impact_value": Decimal(factor)
-                    * Decimal(epdimpact.value)
-                    / Decimal(p.epd.declared_amount)  # Normalise by base amount
-                    / Decimal(total_floor_area),  # Normalise by total floor area
-                }
-            )
-        return container
+        Priority 1: user-entered thickness (input_unit == cm, stored in cm).
+        Priority 2: derive from EPD — area_density / volume_density.
+        """
+        if p.input_unit == Unit.CM and p.quantity is not None:
+            return Decimal(str(p.quantity)) / Decimal("100")
+
+        area_density = _epd_conversion("area density")
+        volume_density = _epd_conversion("volume density")
+        if area_density is not None and volume_density is not None and volume_density != 0:
+            return area_density / volume_density
+
+        raise ImpactCalculationError(
+            f"Layer thickness required but not available for '{p.epd.name}'. "
+            "Not set on product and cannot be derived from EPD conversions "
+            "(both area density and volume density must exist to derive it)."
+        )
+
+    def _cross_section_m2() -> Decimal:
+        """Return cross-section in m² (stored in cm² on product, ÷ 10,000)."""
+        if p.input_unit == Unit.CM2 and p.quantity is not None:
+            return Decimal(str(p.quantity)) / Decimal("10000")
+        raise ImpactCalculationError(
+            f"Cross section (cm²) required but not set on product for '{p.epd.name}'."
+        )
+
+    # ------------------------------------------------------------------
+    # BoQ: infer dimension from input_unit
+    # ------------------------------------------------------------------
+
+    def _fetch_dimension_for_boq() -> AssemblyDimension | None:
+        boq_dim_map = {
+            Unit.PCS: None,
+            Unit.M:   AssemblyDimension.LENGTH,
+            Unit.M2:  AssemblyDimension.AREA,
+            Unit.M3:  AssemblyDimension.VOLUME,
+            Unit.KG:  AssemblyDimension.MASS,
+        }
+        return boq_dim_map[p.input_unit]
+
+    # ------------------------------------------------------------------
+    # Resolve effective dimension
+    # ------------------------------------------------------------------
+
+    eff_dim = _fetch_dimension_for_boq() if p.assembly.is_boq else dimension
+
+    # ------------------------------------------------------------------
+    # Composite validation: mass assembly shares must sum to 100%
+    # ------------------------------------------------------------------
+
+    if eff_dim == AssemblyDimension.MASS:
+        products = getattr(p.assembly, "prefetched_products", None)
+        if products is None:
+            products = list(p.assembly.structuralproduct_set.all())
+        percent_products = [sp for sp in products if sp.input_unit == Unit.PERCENT]
+        if percent_products:
+            total_share = sum(Decimal(str(sp.quantity)) for sp in percent_products)
+            if round(total_share, 4) != Decimal("100"):
+                raise ImpactCalculationError(
+                    f"Share of mass must sum to 100% for assembly '{p.assembly.name}'. "
+                    f"Current total: {total_share}%."
+                )
+
+    # ------------------------------------------------------------------
+    # Factor resolution
+    # ------------------------------------------------------------------
 
     declared_unit = p.epd.declared_unit
+    assembly_qty = Decimal(str(assembly_quantity))
 
-    if p.assembly.is_boq:
-        # For BoQs assembly-level dimension is irrelevant as assembly quantity is fixed to 1.
-        dimension = fetch_dimension_for_boq(p.input_unit)
-
-    quantity = p.quantity / 100 if p.input_unit == Unit.PERCENT else p.quantity
-
-    cm_to_m = 100
-
-    match (dimension, declared_unit):
-        case (_, Unit.PCS):
-            # impact = impact_per_unit * number of pieces / epd_base_amount
-            impacts = calculate_impact(quantity)
-
-        case (AssemblyDimension.AREA, Unit.M2):
-            # impact = impact_per_unit * total_m2 * num_layers / epd_base_amount
-            impacts = calculate_impact(Decimal(assembly_quantity) * Decimal(quantity))
-        case (AssemblyDimension.AREA, Unit.M3):
-            # impact = impact_per_unit * total_m2 * thickness_in_cm * unit_conversion_cm_to_m / epd_base_amount
-            impacts = calculate_impact(
-                Decimal(assembly_quantity) * Decimal(quantity) / Decimal(cm_to_m)
+    # Step 1 — pcs EPD: assembly_quantity always ignored
+    if declared_unit == Unit.PCS:
+        if p.quantity is None:
+            raise ImpactCalculationError(
+                f"Pieces per assembly unit not entered for '{p.epd.name}'. "
+                "Required for pcs EPDs."
             )
-        case (AssemblyDimension.AREA, Unit.KG):
-            # impact = impact_per_unit * conversion_kg_per_m2 * total_m2 * thickness_in_cm * unit_conversion_cm_to_m / epd_base_amount
-            conversion_f = fetch_conversion("kg/m^3")
-            impacts = calculate_impact(
-                Decimal(assembly_quantity)
-                * Decimal(quantity)
-                * Decimal(conversion_f)
-                / Decimal(cm_to_m)
-            )
+        factor = Decimal(str(p.quantity))
 
-        case (AssemblyDimension.VOLUME, Unit.M3):
-            # impact = impact_per_unit * total_m3 / epd_base_amount
-            impacts = calculate_impact(Decimal(assembly_quantity) * Decimal(quantity))
-        case (AssemblyDimension.VOLUME, Unit.KG):
-            # impact = impact_per_unit * conversion_kg_per_m3 * total_m3 * percentage / epd_base_amount
-            conversion_f = fetch_conversion("kg/m^3")
-            impacts = calculate_impact(
-                Decimal(assembly_quantity) * Decimal(quantity) * Decimal(conversion_f)
+    else:
+        # Step 2 — direct unit match
+        direct_match = {
+            AssemblyDimension.AREA:   Unit.M2,
+            AssemblyDimension.VOLUME: Unit.M3,
+            AssemblyDimension.MASS:   Unit.KG,
+            AssemblyDimension.LENGTH: Unit.M,
+        }
+        if direct_match.get(eff_dim) == declared_unit:
+            qty = (
+                Decimal(str(p.quantity)) / Decimal("100")
+                if p.input_unit == Unit.PERCENT
+                else Decimal(str(p.quantity))
+            )
+            factor = assembly_qty * qty
+
+        else:
+            # Step 3 — conversion required
+            factor = _resolve_conversion_factor(
+                eff_dim, declared_unit, assembly_qty,
+                _epd_conversion, _resolve_thickness_m, _cross_section_m2, p,
             )
 
-        case (AssemblyDimension.MASS, Unit.KG):
-            # impact = impact_per_unit * total_kg / epd_base_amount
-            impacts = calculate_impact(Decimal(assembly_quantity) * Decimal(quantity))
-        case (AssemblyDimension.MASS, Unit.M3):
-            # impact = impact_per_unit / conversion_kg_per_m3 * total_kg * percentage / epd_base_amount
-            conversion_f = fetch_conversion("kg/m^3")
-            impacts = calculate_impact(
-                Decimal(assembly_quantity) * Decimal(quantity) / Decimal(conversion_f)
+    # ------------------------------------------------------------------
+    # Build impact list
+    # ------------------------------------------------------------------
+
+    impacts_list = getattr(p.epd, "all_impacts", None)
+    if not impacts_list:
+        impacts_list = p.epd.epdimpact_set.all()
+
+    result = []
+    for epdimpact in impacts_list:
+        result.append(
+            {
+                "assembly_id": p.assembly.pk,
+                "epd_id": p.epd.pk,
+                "assembly_category": (
+                    p.classification.category if p.classification else ""
+                ),
+                "material_category": p.epd.category,
+                "impact_type": epdimpact.impact,
+                "impact_value": (
+                    Decimal(str(factor))
+                    * Decimal(str(epdimpact.value))
+                    / Decimal(str(p.epd.declared_amount))
+                    / Decimal(str(total_floor_area))
+                ),
+            }
+        )
+    return result
+
+
+def _resolve_conversion_factor(
+    eff_dim, declared_unit, assembly_qty,
+    _epd_conversion, _resolve_thickness_m, _cross_section_m2, p,
+) -> Decimal:
+    """Step 3: resolve Factor when no direct unit match exists.
+
+    Implements the full conversion paths from the PDF Developer Edition spec.
+    """
+
+    qty_raw = Decimal(str(p.quantity))
+    qty = qty_raw / Decimal("100") if p.input_unit == Unit.PERCENT else qty_raw
+
+    # ---- AREA assembly (m²) ------------------------------------------
+    if eff_dim == AssemblyDimension.AREA:
+
+        if declared_unit == Unit.M3:
+            # Factor = assembly_qty × thickness_m
+            return assembly_qty * _resolve_thickness_m()
+
+        if declared_unit == Unit.KG:
+            # Option B — preferred: area density
+            area_density = _epd_conversion("area density")
+            if area_density is not None:
+                return assembly_qty * area_density
+
+            # Option A — fallback: thickness × volume density
+            volume_density = _epd_conversion("volume density")
+            if volume_density is not None:
+                return assembly_qty * _resolve_thickness_m() * volume_density
+
+            # Option C — last resort: conversion factor to 1 kg
+            conv_factor = _epd_conversion("conversion factor to 1 kg")
+            if conv_factor is not None:
+                return assembly_qty * conv_factor
+
+            raise ImpactCalculationError(
+                f"Cannot convert area assembly to kg for '{p.epd.name}' — "
+                "no area density, volume density, or conversion factor found in EPD conversions."
             )
 
-        case (AssemblyDimension.LENGTH, Unit.M):
-            # impact = impact_per_unit * total_length * num_elements / epd_base_amount
-            impacts = calculate_impact(Decimal(assembly_quantity) * Decimal(quantity))
-        case (AssemblyDimension.LENGTH, Unit.M3):
-            # impact = impact_per_unit * total_length * surface_cross-section_to_m2 / unit_conversion_cm2_to_m2 / epd_base_amount
-            impacts = calculate_impact(
-                Decimal(assembly_quantity) * Decimal(quantity) / Decimal(cm_to_m**2)
-            )
-        case (AssemblyDimension.LENGTH, Unit.KG):
-            # impact = impact_per_unit * conversion_kg_per_m * total_length * surface_cross-section_to_m2 / unit_conversion_cm2_to_m2 / epd_base_amount
-            conversion_f = fetch_conversion("kg/m^3")
-            impacts = calculate_impact(
-                Decimal(assembly_quantity)
-                * Decimal(quantity)
-                * Decimal(conversion_f)
-                / Decimal(cm_to_m**2)
+    # ---- VOLUME assembly (m³) ----------------------------------------
+    if eff_dim == AssemblyDimension.VOLUME:
+
+        if declared_unit == Unit.KG:
+            volume_density = _epd_conversion("volume density")
+            if volume_density is not None:
+                return assembly_qty * qty * volume_density
+
+            conv_factor = _epd_conversion("conversion factor to 1 kg")
+            if conv_factor is not None:
+                return assembly_qty * qty * conv_factor
+
+            raise ImpactCalculationError(
+                f"Cannot convert volume assembly to kg for '{p.epd.name}' — "
+                "volume density and conversion factor both missing from EPD conversions."
             )
 
-        case _:
-            raise ValueError(
-                f"Unsupported combination: dimension '{dimension}', declared_unit '{declared_unit}'"
+        if declared_unit == Unit.M2:
+            # Factor = assembly_qty × qty / thickness_m
+            return assembly_qty * qty / _resolve_thickness_m()
+
+    # ---- MASS assembly (kg) ------------------------------------------
+    if eff_dim == AssemblyDimension.MASS:
+        # constituent_mass = assembly_qty × share_of_mass
+        constituent_mass = assembly_qty * qty
+
+        if declared_unit == Unit.M3:
+            volume_density = _epd_conversion("volume density")
+            if volume_density is not None and volume_density != 0:
+                return constituent_mass / volume_density
+            raise ImpactCalculationError(
+                f"Cannot convert mass assembly to m³ for '{p.epd.name}' — "
+                "volume density missing from EPD conversions. No safe fallback."
             )
 
-    return impacts
+        if declared_unit == Unit.M2:
+            area_density = _epd_conversion("area density")
+            if area_density is not None and area_density != 0:
+                return constituent_mass / area_density
+            raise ImpactCalculationError(
+                f"Cannot convert mass assembly to m² for '{p.epd.name}' — "
+                "area density missing from EPD conversions. No safe fallback."
+            )
+
+    # ---- LENGTH assembly (m) -----------------------------------------
+    if eff_dim == AssemblyDimension.LENGTH:
+
+        if declared_unit == Unit.M3:
+            return assembly_qty * _cross_section_m2()
+
+        if declared_unit == Unit.KG:
+            # Option A — preferred: linear density
+            linear_density = _epd_conversion("linear density")
+            if linear_density is not None:
+                return assembly_qty * linear_density
+
+            # Option B — fallback: cross_section × volume density
+            volume_density = _epd_conversion("volume density")
+            if volume_density is not None:
+                return assembly_qty * _cross_section_m2() * volume_density
+
+            raise ImpactCalculationError(
+                f"Cannot convert length assembly to kg for '{p.epd.name}' — "
+                "linear density missing and cross section or volume density not available."
+            )
+
+    raise ImpactCalculationError(
+        f"Unsupported combination: dimension='{eff_dim}', "
+        f"declared_unit='{declared_unit}' for EPD '{p.epd.name}'."
+    )
 
 
 def calculate_impact_operational(
     p: "OperationalProduct",
 ) -> dict[Literal["gwp_b6", "penrt_b6"], Decimal]:
-    def fetch_conversion(unit) -> Decimal|None:
-        """Fetch conversion factor based on the unit."""
+    """Calculate operational carbon (GWP B6 and PENRT B6)."""
+
+    def fetch_conversion(unit) -> Decimal | None:
         try:
             return next(
-                (c["value"] for c in p.epd.conversions if c["unit"] == unit), None
+                (Decimal(str(c["value"])) for c in p.epd.conversions if c["unit"] == unit),
+                None,
             )
-        except:
+        except Exception:
             return None
 
     def calculate_impact(factor, gwp_impact, penrt_impact):
         return {
-            "gwp_b6": Decimal(factor)
-            * Decimal(gwp_impact)
-            / Decimal(p.epd.declared_amount)  # Normalise by base amount
-            / Decimal(p.building.total_floor_area),  # Normalise by floor area,
-            "penrt_b6": Decimal(factor)
-            * Decimal(penrt_impact)
-            / Decimal(p.epd.declared_amount)  # Normalise by base amount
-            / Decimal(p.building.total_floor_area),  # Normalise by floor area,
+            "gwp_b6": (
+                Decimal(str(factor))
+                * Decimal(str(gwp_impact))
+                / Decimal(str(p.epd.declared_amount))
+                / Decimal(str(p.building.total_floor_area))
+            ),
+            "penrt_b6": (
+                Decimal(str(factor))
+                * Decimal(str(penrt_impact))
+                / Decimal(str(p.epd.declared_amount))
+                / Decimal(str(p.building.total_floor_area))
+            ),
         }
 
     impact_set = p.epd.epdimpact_set.filter(impact__life_cycle_stage="b6")
@@ -189,40 +355,41 @@ def calculate_impact_operational(
         (i.value for i in impact_set if i.impact.impact_category == "penrt"), None
     )
 
-    # TODO: Flexibilise to other declared_units
     match (p.epd.declared_unit, p.input_unit):
 
         case (Unit.KWH, Unit.KWH):
-            impacts = calculate_impact(Decimal(p.quantity), gwp_b6, penrt_b6)
+            impacts = calculate_impact(Decimal(str(p.quantity)), gwp_b6, penrt_b6)
+
         case (Unit.KWH, Unit.M3):
-            kwh_per_kg = fetch_conversion("kg") or fetch_conversion(
-                "-"
-            )  # "-" is used by Ökobdauat for name:'conversion
+            kwh_per_kg = fetch_conversion("kg") or fetch_conversion("-")
             kg_per_m3 = fetch_conversion("kg/m^3")
             impacts = calculate_impact(
-                Decimal(p.quantity) * Decimal(kwh_per_kg) * Decimal(kg_per_m3),
+                Decimal(str(p.quantity)) * Decimal(str(kwh_per_kg)) * Decimal(str(kg_per_m3)),
                 gwp_b6,
                 penrt_b6,
             )
+
         case (Unit.KWH, Unit.LITER):
-            kwh_per_kg = fetch_conversion("kg") or fetch_conversion(
-                "-"
-            )  # "-" is used by Ökobdauat for name:'conversion
+            kwh_per_kg = fetch_conversion("kg") or fetch_conversion("-")
             kg_per_m3 = fetch_conversion("kg/m^3")
             impacts = calculate_impact(
-                Decimal(p.quantity) * Decimal(kwh_per_kg) * Decimal(kg_per_m3) / 1000,
+                Decimal(str(p.quantity)) * Decimal(str(kwh_per_kg)) * Decimal(str(kg_per_m3)) / Decimal("1000"),
                 gwp_b6,
                 penrt_b6,
             )
+
         case (Unit.KWH, Unit.KG):
-            kwh_per_kg = fetch_conversion("kg") or fetch_conversion("-")  # "-" is used by Ökobdauat for name:'conversion factor to 1 kg'
+            kwh_per_kg = fetch_conversion("kg") or fetch_conversion("-")
             impacts = calculate_impact(
-                Decimal(p.quantity) * Decimal(kwh_per_kg), gwp_b6, penrt_b6
+                Decimal(str(p.quantity)) * Decimal(str(kwh_per_kg)),
+                gwp_b6,
+                penrt_b6,
             )
 
         case _:
             raise ValueError(
-                f"Unsupported combination: declared_unit '{p.epd.declared_unit}', input_unit '{p.input_unit}'"
+                f"Unsupported combination: declared_unit '{p.epd.declared_unit}', "
+                f"input_unit '{p.input_unit}'"
             )
 
     return impacts


### PR DESCRIPTION
 ## Summary

This PR implements the full carbon emission calculation engine for the single building dashboard, based on the two PDF specification documents:

  - *Formula Reference — Embodied Carbon A1-A3 / Developer Edition*
  - *Corrected Formula Reference — Section 2: Embodied Carbon (Full Update)*

  ---

  ## What was implemented

  ### Core formula
  Emissions [kgCO₂e/m²] = Factor × (EPDImpact.value / EPD.declared_amount) / total_floor_area

  ### Factor resolution—3-step logic (embodied carbon A1–A3)

  **Step 1 — pcs EPD**
  If `EPD.declared_unit == pcs`, Factor = `StructuralProduct.quantity` (pieces per assembly unit). Missing quantity blocks the calculation.

  **Step 2 — direct unit match**
  If the assembly dimension unit matches the EPD declared unit directly (e.g. AREA↔m², VOLUME↔m³, MASS↔kg, LENGTH↔m), Factor = `assembly_quantity ×
  product_quantity`. Percent input units are divided by 100 first.

  **Step 3 — conversion paths (all implemented)**

  | Assembly dimension | EPD declared unit | Path |
  |---|---|---|
  | AREA | m³ | `assembly_qty × thickness_m` |
  | AREA | kg | area density (preferred) → thickness × volume density → conversion factor → block |
  | VOLUME | kg | volume density → conversion factor → block |
  | VOLUME | m² | `assembly_qty × qty / thickness_m` |
  | MASS | m³ | `constituent_mass / volume_density` (no fallback — block if missing) |
  | MASS | m² | `constituent_mass / area_density` (no fallback — block if missing) |
  | LENGTH | m³ | `assembly_qty × cross_section_m²` |
  | LENGTH | kg | linear density (preferred) → cross section × volume density → block |

  ### EPD conversion lookup
  Lookup is done by `name` key first (`"volume density"`, `"area density"`, `"linear density"`, `"conversion factor to 1 kg"`) as specified in the Developer     
  Edition PDF. Falls back to unit-string matching (`"kg/m^3"`, `"kg/m^2"`, `"kg/m"`, `"-"`) for legacy EPD data that lacks the `name` field.

  ### Thickness resolution (`_resolve_thickness_m`)                                                                                                              
  Priority 1: user-entered thickness when `input_unit == cm` (stored in cm, converted to metres).
  Priority 2: derived from EPD conversions as `area_density / volume_density`.                                                                                   
  Missing thickness blocks the calculation with a descriptive error.                                                                                             
                                                                                                                                                                 
  ### Composite validation                                                                                                                                       
  For MASS assemblies, all percent-input products must sum to exactly 100%. If they don't, the calculation is blocked with an error before any factor is         
  computed.                                                                                                                                                                                                                  
  ### BoQ assemblies                                                                                                                                             
  When `Assembly.is_boq = True`, the assembly-level dimension is ignored. Dimension is inferred from the product's `input_unit` instead (m→LENGTH, m²→AREA,
  m³→VOLUME, kg→MASS, pcs→pcs path).                                                                                                                                
  ### Operational carbon (GWP B6 / PENRT B6)                                                                                                                     
  All four supported unit combinations implemented:         
  - `kwh EPD + kwh input` — direct                                                                                                                               
  - `kwh EPD + m³ input` — via kwh/kg and kg/m³ conversions                                                                                                      
  - `kwh EPD + liter input` — same as m³ path ÷ 1000                                                                                                             
  - `kwh EPD + kg input` — via kwh/kg conversion                                                                                                                 
                                                                                                                                                                 
  ### Migration fix                                                                                                                                              
  Migration `0031_assembly_template_fields` had a raw SQL type mismatch: `from_template_id` was declared as `integer` but `Assembly.id` is UUID. Fixed to `uuid`.                                                                                                                                                                 
  ### Dashboard integration                                                                                                                                      
  All four tabs on the single building page read from real calculations:                                                                                         
  - **Assembly tab** — whole life carbon doughnut (embodied + operational) + embodied carbon by assembly category bar chart                                      
  - **Materials tab** — embodied carbon by material category bar chart                                                                                           
  - **Energy tab** — operational carbon (B6) by system type bar chart                                                                                            
  - **Header stats** — Carbon Footprint, Embodied Carbon, Operational Carbon, Carbon Savings %                                                                   
                                                                                                                                                                 
  ### Tests                                                                                                                                                      
  36/36 tests pass, covering every PDF-specified conversion path, blocking conditions, legacy fallback behaviour, BoQ inference, and composite validation.       
                                                                                                                                                                   ---                                                       
                                                                                                                                                                 
  ## What was NOT implemented and why                                                                                                                               
  ### Savings tab                                                                                                                                                
  The Savings tab on the building detail page still displays hardcoded placeholder data. The two PDFs do not define a savings calculation formula. Savings
  potential requires:                                                                                                                                               
  1. A **simulated/baseline building** to compare against (stored in `BuildingAssemblySimulated` / `SimulatedOperationalProduct`)                                
  2. A benchmarking dataset (national averages, best-practice thresholds by building type and region)
                                                                                                                                                                 
  Neither of these is specified in the PDF spec. The `carbon_savings_percentage` field in the backend is wired up and will show real values as soon as a           simulated baseline is attached to the building, but the Savings tab UI itself remains a mockup pending a separate specification for that feature.