### PR TITLE
fix: catch ImpactCalculationError in get_assemblies to prevent building page returning 500

### DIFF
--- a/pages/tests/test_impact_calculation.py
+++ b/pages/tests/test_impact_calculation.py
@@ -34,6 +34,9 @@ from pages.models.epd import (
     MaterialCategory,
     Unit,
 )
+from pages.models.building import Building, BuildingAssembly
+from pages.models.climate_type import ClimateType
+from pages.views.building.building import get_assemblies
 from pages.views.building.impact_calculation import calculate_impacts, ImpactCalculationError
 
 
@@ -549,3 +552,86 @@ def test_model_validation_rejects_invalid_units(
     assembly = create_assembly(dimension=dimension)
     with pytest.raises(ValidationError):
         create_product(assembly, epd, quantity, product_unit)
+
+
+# ---------------------------------------------------------------------------
+# Regression: get_assemblies() must not crash on ImpactCalculationError
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def building():
+    climate, _ = ClimateType.objects.get_or_create(name="cold")
+    return Building.objects.create(
+        name="Test Building",
+        climate_zone=climate,
+        total_floor_area=100,
+    )
+
+
+@pytest.mark.django_db
+def test_get_assemblies_skips_product_with_missing_thickness(
+    building, create_epd, create_epd_impact, create_assembly, create_product
+):
+    """Regression: AREA+m³ EPD with no thickness and no EPD conversions raises
+    ImpactCalculationError. get_assemblies() must catch it and return the assembly
+    with impacts=0 rather than propagating a 500 error to the building page.
+    """
+    # AREA assembly + m³ EPD with no conversions → _resolve_thickness_m() will raise
+    epd = create_epd("AAC (autoclaved aerated concrete) block", Unit.M3, [])
+    create_epd_impact(epd, Decimal("0.35"))
+    assembly = create_assembly(AssemblyDimension.AREA)
+    # Save product with CM unit (valid), then clear quantity to force EPD-derived path
+    p = create_product(assembly, epd, Decimal("5"), Unit.CM)
+    p.input_unit = Unit.UNKNOWN  # override at runtime so no user thickness is available
+    assembly.prefetched_products = [p]
+
+    b_assembly = BuildingAssembly.objects.create(
+        assembly=assembly,
+        building=building,
+        quantity=50,
+        reporting_life_cycle=50,
+    )
+    b_assembly.assembly = assembly  # ensure prefetched_products is attached
+
+    structural_components, impact_list = get_assemblies([b_assembly])
+
+    # Page must not crash — assembly appears with zero impact
+    assert len(structural_components) == 1
+    assert structural_components[0]["impacts"] == 0
+    assert impact_list == []
+
+
+@pytest.mark.django_db
+def test_get_assemblies_keeps_good_product_when_one_fails(
+    building, create_epd, create_epd_impact, create_assembly, create_product
+):
+    """When one product in an assembly raises ImpactCalculationError and another
+    succeeds, only the good product's impacts are included.
+    """
+    # Good product: AREA + m² → direct match, no conversion needed
+    epd_good = create_epd("Good slab", Unit.M2, [])
+    create_epd_impact(epd_good, Decimal("4"))
+    # Bad product: AREA + m³, no conversions → thickness missing → raises
+    epd_bad = create_epd("Bad AAC block", Unit.M3, [])
+    create_epd_impact(epd_bad, Decimal("0.35"))
+
+    assembly = create_assembly(AssemblyDimension.AREA)
+    p_good = create_product(assembly, epd_good, Decimal("1"), Unit.UNKNOWN)
+    p_bad = create_product(assembly, epd_bad, Decimal("5"), Unit.CM)
+    p_bad.input_unit = Unit.UNKNOWN  # force EPD-derived thickness path
+    assembly.prefetched_products = [p_good, p_bad]
+
+    b_assembly = BuildingAssembly.objects.create(
+        assembly=assembly,
+        building=building,
+        quantity=1,
+        reporting_life_cycle=50,
+    )
+    b_assembly.assembly = assembly
+
+    structural_components, impact_list = get_assemblies([b_assembly])
+
+    assert len(structural_components) == 1
+    # Only p_good's impact: Factor=1×1=1, impact=4×1/1/100=0.04
+    assert structural_components[0]["impacts"] > 0
+    assert len(impact_list) == 1

--- a/pages/views/building/building.py
+++ b/pages/views/building/building.py
@@ -348,14 +348,17 @@ def get_assemblies(assembly_list: list[BuildingAssembly]):
     for b_assembly in assembly_list:
         assembly_impact_list = []
         for p in getattr(b_assembly.assembly, "prefetched_products", []):
-            assembly_impact_list.extend(
-                calculate_impacts(
-                    b_assembly.assembly.dimension,
-                    b_assembly.quantity,
-                    b_assembly.building.total_floor_area,
-                    p,
+            try:
+                assembly_impact_list.extend(
+                    calculate_impacts(
+                        b_assembly.assembly.dimension,
+                        b_assembly.quantity,
+                        b_assembly.building.total_floor_area,
+                        p,
+                    )
                 )
-            )
+            except (ValueError, AttributeError, ZeroDivisionError):
+                continue
 
         # get GWP impact for each assembly to display in list
         gwpa1a3 = [


### PR DESCRIPTION
## Summary

- `get_assemblies()` in `building.py` was calling `calculate_impacts()` with no error handling. Any product with missing EPD conversion data (e.g. no thickness, no area/volume density) raised an unhandled `ImpactCalculationError`, crashing the entire building detail page with a 500.
- Wrapped the `calculate_impacts()` call in a `try/except (ValueError, AttributeError, ZeroDivisionError)` — `ImpactCalculationError` is a `ValueError` subclass so it is caught. The offending product is skipped and the rest of the page loads normally.
- Added two regression tests to `test_impact_calculation.py` using the existing pytest/DB fixture pattern: one verifies the page survives a fully broken product, the other verifies a bad product doesn't suppress a good product's impacts in the same assembly.

## Root cause

The QA building had an AREA assembly containing an 'AAC (autoclaved aerated concrete) block' product. Its EPD is declared in m³, so the code requires a layer thickness. No thickness was entered on the product and the EPD had neither area density nor volume density to derive one from — exactly the blocking condition specified in the PDF spec. Locally this building didn't exist, which is why the error wasn't reproducible.

## Test plan

- [x] 31/31 tests pass in `test_impact_calculation.py`
- [ ] Navigate to the affected building on QA — page loads, the problematic assembly shows with 0 impact instead of 500
- [ ] Buildings with fully valid EPD data are unaffected
