### PR TITLE
fix: resolve cookie banner JS errors, unit label typo, and EPD unit mismatch guard

### DIFF
--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -24,11 +24,124 @@ from pages.models.assembly import (
 )
 from pages.models.base import ALCBTCountryManager
 from pages.models.building import Building, BuildingAssembly
-from pages.models.epd import EPD, MaterialCategory
+from pages.models.epd import EPD, MaterialCategory, Unit
 from pages.views.assembly.epd_filtering import get_filtered_epd_list
 from pages.views.assembly.epd_processing import get_epd_list
 
 logger = logging.getLogger(__name__)
+
+
+def _epd_has_conversion(epd, name):
+    """Return the conversion value by name from the EPD's conversions field, or None."""
+    if not epd.conversions:
+        return None
+    for item in epd.conversions:
+        if item.get("name") == name:
+            try:
+                return float(item.get("value", 0)) or None
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _can_epd_be_used(dimension: str, epd) -> tuple[bool, str]:
+    """
+    Check whether the EPD can be converted for the given assembly dimension.
+    Returns (True, "") if usable, or (False, reason_message) if not.
+
+    Mirrors the logic in _resolve_conversion_factor so we catch mismatches
+    before the user adds the EPD rather than only at calculation time.
+    """
+    declared = epd.declared_unit
+
+    # PCS dimension only accepts PCS epds (and vice-versa)
+    if dimension == AssemblyDimension.PCS:
+        if declared == Unit.PCS:
+            return True, ""
+        return False, (
+            f"This EPD is declared in '{declared}'. "
+            f"A Pieces (pcs) component only accepts EPDs declared in pcs."
+        )
+
+    if declared == Unit.PCS:
+        if dimension == AssemblyDimension.PCS:
+            return True, ""
+        return False, (
+            f"This EPD is declared in pieces (pcs) and cannot be used in a "
+            f"'{dimension}' component without a conversion factor."
+        )
+
+    # Direct unit match — always fine
+    direct_match = {
+        AssemblyDimension.AREA: Unit.M2,
+        AssemblyDimension.VOLUME: Unit.M3,
+        AssemblyDimension.MASS: Unit.KG,
+        AssemblyDimension.LENGTH: Unit.M,
+    }
+    if declared == direct_match.get(dimension):
+        return True, ""
+
+    # AREA assembly
+    if dimension == AssemblyDimension.AREA:
+        if declared == Unit.M3:
+            return True, ""  # needs thickness — entered by user
+        if declared == Unit.KG:
+            if (_epd_has_conversion(epd, "area density") or
+                    _epd_has_conversion(epd, "volume density") or
+                    _epd_has_conversion(epd, "conversion factor to 1 kg")):
+                return True, ""
+            return False, (
+                f"Cannot add this EPD (declared in kg) to an area (m²) component: "
+                "no area density, volume density, or conversion factor is available for this EPD."
+            )
+
+    # VOLUME assembly
+    if dimension == AssemblyDimension.VOLUME:
+        if declared == Unit.KG:
+            if (_epd_has_conversion(epd, "volume density") or
+                    _epd_has_conversion(epd, "conversion factor to 1 kg")):
+                return True, ""
+            return False, (
+                f"Cannot add this EPD (declared in kg) to a volume (m³) component: "
+                "no volume density or conversion factor is available for this EPD."
+            )
+        if declared == Unit.M2:
+            return True, ""  # needs thickness
+
+    # MASS assembly
+    if dimension == AssemblyDimension.MASS:
+        if declared == Unit.M3:
+            if _epd_has_conversion(epd, "volume density"):
+                return True, ""
+            return False, (
+                f"Cannot add this EPD (declared in m³) to a mass (kg) component: "
+                "no volume density is available for this EPD."
+            )
+        if declared == Unit.M2:
+            if _epd_has_conversion(epd, "area density"):
+                return True, ""
+            return False, (
+                f"Cannot add this EPD (declared in m²) to a mass (kg) component: "
+                "no area density is available for this EPD."
+            )
+
+    # LENGTH assembly
+    if dimension == AssemblyDimension.LENGTH:
+        if declared == Unit.M3:
+            return True, ""  # needs cross-section
+        if declared == Unit.KG:
+            if (_epd_has_conversion(epd, "linear density") or
+                    _epd_has_conversion(epd, "volume density")):
+                return True, ""
+            return False, (
+                f"Cannot add this EPD (declared in kg) to a length (m) component: "
+                "no linear density or volume density is available for this EPD."
+            )
+
+    return False, (
+        f"This EPD (declared in '{declared}') is not compatible with a "
+        f"'{dimension}' component and no conversion factor exists to bridge the unit mismatch."
+    )
 
 
 @login_required
@@ -121,6 +234,12 @@ def handle_select_product(request):
             available_units = [epd.declared_unit]
         elif isinstance(available_units, set):
             available_units = sorted(list(available_units))
+
+        # For component mode, block the add if no valid conversion path exists.
+        if mode == "component":
+            ok, reason = _can_epd_be_used(dimension, epd)
+            if not ok:
+                return HttpResponse(reason, status=422)
 
         # For BoQ mode, always use the EPD's declared unit — the user selects
         # from available_units via a dropdown so dimension logic doesn't apply.

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -371,7 +371,7 @@
   </dialog>
 
   <script>
-    var i18n = {
+    var cookieI18n = {
       cookieSaveFailed: "{% translate 'Failed to save cookie preferences. Please try again.' %}",
       alwaysActive:     "{% translate 'Always Active' %}",
     };
@@ -473,7 +473,7 @@
                   </div>
                   <div class="flex items-center gap-2 shrink-0">
                     ${group.required
-                      ? `<span class="badge badge-sm badge-neutral">${i18n.alwaysActive}</span>
+                      ? `<span class="badge badge-sm badge-neutral">${cookieI18n.alwaysActive}</span>
                          <input type="checkbox" class="toggle toggle-sm toggle-primary" id="cookie-${group.id}" checked disabled>`
                       : `<input type="checkbox" class="toggle toggle-sm toggle-primary" id="cookie-${group.id}" ${group.enabled ? 'checked' : ''}>`
                     }
@@ -513,27 +513,23 @@
                     console.error(`Failed to save ${group.id} cookie setting:`, response.status);
                     throw new Error(`Failed to save ${group.id} cookie setting`);
                   }
-                  return [...results, response];
-                });
-              }
-              return results;
-            });
-          }, Promise.resolve([]));
+                  return response;
+                })
+              );
+            }
+          });
+
+          return Promise.all(promises);
         })
-        .then(responses => {
-          const allOk = responses.every(response => response.ok);
-          if (allOk) {
-            setBannerShownCookie();
-            hideCookieBanner();
-            cookieSettingsModal.close();
-            setTimeout(() => location.reload(), 300);
-          } else {
-            console.error('Some cookie settings failed to save');
-          }
+        .then(() => {
+          setBannerShownCookie();
+          hideCookieBanner();
+          cookieSettingsModal.close();
+          setTimeout(() => location.reload(), 300);
         })
         .catch(error => {
           console.error('Error saving cookie settings:', error);
-          alert(i18n.cookieSaveFailed);
+          alert(cookieI18n.cookieSaveFailed);
         });
     }
 

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -1432,4 +1432,16 @@
     }
   {% endif %}
 })();
+
+// Show a toast error when the server rejects an EPD add (e.g. unit mismatch)
+document.body.addEventListener('htmx:responseError', function(evt) {
+  var xhr = evt.detail.xhr;
+  if (!xhr) return;
+  var target = evt.detail.target;
+  // Only handle errors aimed at the component or structural materials lists
+  if (target && (target.id === 'component_materials_list' || target.id === 'structural_materials_list')) {
+    var msg = xhr.responseText || 'This EPD cannot be added due to a unit mismatch.';
+    if (window.Toast) Toast.error(msg, { duration: 6000 });
+  }
+});
 </script>

--- a/templates/pages/home/partials/buildings_list.html
+++ b/templates/pages/home/partials/buildings_list.html
@@ -94,7 +94,7 @@
                   >
                   <span
                     class="text-base/6 font-medium text-[var(--text--sub-600)]"
-                    >{{ building.total_floor_area|floatformat:"0" }} m<sup>3</sup></span
+                    >{{ building.total_floor_area|floatformat:"0" }} m<sup>2</sup></span
                   >
                 </li>
                 <li


### PR DESCRIPTION
## Summary

  This branch addresses several issues reported by QA against the new UI flow.

  ### 1. Cookie banner buttons non-functional (all pages)

  The `saveCustomSettings()` function in `templates/_base.html` had a JavaScript syntax error caused by a corrupted
  merge of two different patterns (`reduce`-based and `Promise.all`-based). This broke the entire `<script>` block at
  parse time, making `acceptAllCookies`, `declineOptionalCookies`, and `showCookieSettings` all undefined — so none of
  the cookie banner buttons worked.

  **Fix:** Rewrote `saveCustomSettings()` as a clean `Promise.all` implementation.

  ### 2. "Always Active" badge showing "undefined" in cookie settings modal

  The cookie script block used `var i18n` which was being overwritten at runtime by the many other page-level `var i18n
  = {...}` declarations that don't include an `alwaysActive` key.

  **Fix:** Renamed the cookie-specific object to `cookieI18n` to avoid collisions.

  ### 3. Total floor area showing m³ instead of m² on building listing

  A typo in `templates/pages/home/partials/buildings_list.html` used `<sup>3</sup>` instead of `<sup>2</sup>`.

  **Fix:** Corrected the superscript to `2`.

  ### 4. EPD unit mismatch not prevented when adding to a structural component

  Users could add EPDs to a component even when no valid unit conversion path existed between the EPD's declared unit
  and the component's dimension (e.g. a `pcs`-declared EPD added to an `area` component). The unit mismatch would only
  surface silently at calculation time.

  **Fix:**
  - Added `_can_epd_be_used(dimension, epd)` in `pages/views/building/building_step_structural.py` which mirrors the
  conversion logic from `_resolve_conversion_factor()` to validate compatibility upfront.
  - `handle_select_product()` now calls this check for `mode=component` and returns HTTP 422 with a descriptive error
  message if incompatible.
  - Added an `htmx:responseError` listener in `building-structural-components.html` that catches the 422 and displays
  the reason as a `Toast.error()` notification.

  ## Test plan

  - [x] Cookie banner appears on first visit and all three buttons (Accept All, Decline Optional, Manage Preferences)
  work correctly
  - [x] Cookie settings modal shows "Always Active" (not "undefined") for essential cookies
  - [x] Building listing shows m² (not m³) for Total floor area
  - [x] Adding a `pcs`-declared EPD to an `area/volume/mass/length` component is blocked with a toast error
  - [x] Adding a `kg`-declared EPD with a volume density to an `area` component is still allowed
  - [x] Adding an `m3`-declared EPD to an `area` component is still allowed (shows cm thickness input)
  - [x] Cookie banner does not appear on subsequent visits after accepting/declining