### PR TITLE
fix: toast always renders above dialogs

### DIFF
--- a/libs/toast.js
+++ b/libs/toast.js
@@ -22,14 +22,15 @@ class ToastNotification {
 
     /**
      * Initialize the toast container if it doesn't exist
-     * Handles native HTML dialogs by appending inside open dialogs
+     * Always appends to document.body so toasts render above any open
+     * <dialog> stacking context.
      */
     initContainer(position) {
         const containerId = `toast-stack-${position}`;
 
-        // Check for open native dialog (top layer)
-        const openDialog = document.querySelector('dialog[open]');
-        const parent = openDialog || document.body;
+        // Always use body as parent — dialogs create their own stacking context
+        // which would clip toasts rendered inside them.
+        const parent = document.body;
 
         // Look for existing container in the correct parent
         let container = parent.querySelector(`#${containerId}`);

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -1434,13 +1434,14 @@
 })();
 
 // Show a toast error when the server rejects an EPD add (e.g. unit mismatch)
-document.body.addEventListener('htmx:responseError', function(evt) {
+document.body.addEventListener('htmx:afterRequest', function(evt) {
+  if (evt.detail.successful) return;
   var xhr = evt.detail.xhr;
   if (!xhr) return;
   var target = evt.detail.target;
   // Only handle errors aimed at the component or structural materials lists
   if (target && (target.id === 'component_materials_list' || target.id === 'structural_materials_list')) {
-    var msg = xhr.responseText || 'This EPD cannot be added due to a unit mismatch.';
+    var msg = (xhr.responseText || '').trim() || 'This EPD cannot be added due to a unit mismatch.';
     if (window.Toast) Toast.error(msg, { duration: 6000 });
   }
 });


### PR DESCRIPTION
## Summary

Fix toast notifications rendering behind open `<dialog>` elements due to stacking context isolation.

  ## Problem

 `Toast.initContainer()` appended the toast container inside the nearest open `<dialog>` element. Native `<dialog>` elements create an isolated stacking context, so toasts rendered inside them appeared behind the dialog or were not visible at all.

  ## Fix

  - **`libs/toast.js`**: Removed the `dialog[open]` parent logic. The toast container now always appends to `document.body`, which sits in the top-level stacking context and guarantees toasts are always visible regardless of open dialogs.
  - **`building-structural-components.html`**: Switched the error event listener from `htmx:responseError` to `htmx:afterRequest` (checking `evt.detail.successful === false`) — HTMX 2.x does not fire `htmx:responseError` for non-2xx responses.

  ## Test plan

  - [x] Trigger a unit mismatch error (e.g. add a `pcs` EPD to an `area` component) — toast error should appear visibly
  above the EPD modal
  - [x] Toast notifications triggered outside of dialogs still appear correctly