### PR TITLE
fix: add building flow guards, EPD unit mismatch inline error, GWP fixes, chart improvements

### DIFF
--- a/libs/step-manager.js
+++ b/libs/step-manager.js
@@ -455,7 +455,32 @@ class StepManager {
     const contentArea = document.getElementById("dynamic-content");
 
     if (!contentArea) return;
-  
+
+    // In add mode, guard any step beyond step 1 substep 1 when there is no building UUID.
+    // This prevents accessing later steps without completing Name & Location first.
+    // Check both URL and formData — after saving step 1 the UUID is stored in formData
+    // before updateUrl() has had a chance to put it in the URL.
+    const hasUuid = this.getBuildingId()
+      || this.formData['building-information/building-name-location']?.building_uuid;
+    const isNameLocationStep = this.currentStep === 1 && this.currentSubStep === 1;
+    if (!this.editMode && !hasUuid && !isNameLocationStep) {
+      contentArea.innerHTML = `
+        <div class="flex flex-col items-center justify-center h-64 text-center gap-4">
+          <div class="alert alert-warning max-w-md">
+            <div>
+              <p class="font-semibold">${gettext("No building found.")}</p>
+              <p class="text-sm mt-1">${gettext("Please start by filling in the Building Name & Location, or go to an existing building to edit it.")}</p>
+            </div>
+          </div>
+          <div class="flex gap-3">
+            <a href="/building/_new" class="btn btn-primary btn-sm">${gettext("Create New Building")}</a>
+            <a href="/" class="btn btn-outline btn-sm">${gettext("Go to Dashboard")}</a>
+          </div>
+        </div>
+      `;
+      return;
+    }
+
     // Show loading state
     contentArea.innerHTML = `
       <div class="flex items-center justify-center h-64">
@@ -586,6 +611,7 @@ class StepManager {
     const subStep = step.subSteps[this.currentSubStep - 1];
     const saveBtn = document.getElementById("save-and-continue");
     const goBackBtn = document.getElementById("go-back");
+    const skipBtn = document.getElementById("skip");
 
     if (saveBtn) {
       const isValid = this.validateCurrentStep();
@@ -603,8 +629,25 @@ class StepManager {
     }
 
     if (goBackBtn) {
-      const isFirstStep = this.currentStep === 1 && this.currentSubStep === 1;
-      goBackBtn.disabled = isFirstStep;
+      const isFirstSubStep = this.currentStep === 1 && this.currentSubStep === 1;
+      // In add mode, disable Go Back on step 1 substep 2 (Building Details) —
+      // once a building is created the user cannot go back to Name & Location.
+      const hasUuid = this.getBuildingId()
+        || this.formData['building-information/building-name-location']?.building_uuid;
+      const isLockedOnBuildingDetails = !this.editMode && hasUuid &&
+        this.currentStep === 1 && this.currentSubStep === 2;
+      goBackBtn.disabled = isFirstSubStep || !!isLockedOnBuildingDetails;
+    }
+
+    if (skipBtn) {
+      // In add mode: hide skip on step 1 substep 1 (Name & Location) and
+      // step 1 substep 2 (Building Details) — both are unskippable.
+      if (!this.editMode) {
+        const isUnskippable = this.currentStep === 1;
+        skipBtn.style.display = isUnskippable ? 'none' : '';
+      } else {
+        skipBtn.style.display = '';
+      }
     }
   }
 
@@ -1163,7 +1206,15 @@ class StepManager {
 
   
   goToStep(step) {
-    this.currentStep = parseInt(step);
+    const targetStep = parseInt(step);
+    // In add mode, once a building is created, step 1 substep 1 (Name & Location) is locked.
+    // Clicking step 1 in the nav would land on substep 1, so block it entirely.
+    const hasUuid = this.getBuildingId()
+      || this.formData['building-information/building-name-location']?.building_uuid;
+    if (!this.editMode && hasUuid && targetStep === 1) {
+      return;
+    }
+    this.currentStep = targetStep;
     this.currentSubStep = 1;
     this.renderStepNavigation();
     this.updateCurrentStepInfo();
@@ -1173,8 +1224,16 @@ class StepManager {
   }
 
   goToSubStep(step, subStep) {
-    this.currentStep = parseInt(step);
-    this.currentSubStep = parseInt(subStep);
+    const targetStep = parseInt(step);
+    const targetSubStep = parseInt(subStep);
+    // In add mode, once a building is created, step 1 substep 1 (Name & Location) is locked.
+    const hasUuid = this.getBuildingId()
+      || this.formData['building-information/building-name-location']?.building_uuid;
+    if (!this.editMode && hasUuid && targetStep === 1 && targetSubStep === 1) {
+      return;
+    }
+    this.currentStep = targetStep;
+    this.currentSubStep = targetSubStep;
     this.renderStepNavigation();
     this.updateCurrentStepInfo();
     this.loadCurrentStep();

--- a/pages/views/building/add_building_steps.py
+++ b/pages/views/building/add_building_steps.py
@@ -448,7 +448,7 @@ def handle_structural_components_step(request):
                         'quantity': float(sp.quantity),
                         'unit': sp.input_unit,
                         'description': sp.description or '',
-                        'gwp': float(sp.epd.get_gwp_impact_sum("A1-A3") or 0),
+                        'gwp': float(sp.epd.get_gwp_impact_sum("a1a3") or 0),
                         'country': sp.epd.country.name if sp.epd.country else 'Unknown',
                     }
 
@@ -579,7 +579,7 @@ def save_building_step(request):
                     latitude=step_data.get('latitude') if step_data.get('latitude') else None,
                     created_by=request.user,
                     # Add minimal defaults for required fields
-                    climate_zone='tropical-wet',  # Default, will be updated in step 1.2
+                    climate_zone=None,  # Will be updated in step 1.2
                     total_floor_area=100,  # Will be updated in step 1.2
                     reference_period=50,    # Will be updated in step 1.2
                 )

--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -263,7 +263,7 @@ def handle_select_product(request):
             "selection_text": selection_text,
             "timestamp": datetime.now().strftime("%Y%m%d%H%M%S%f"),
             "available_units": available_units,
-            "gwp": epd.get_gwp_impact_sum("A1-A3") or 0,
+            "gwp": epd.get_gwp_impact_sum("a1a3") or 0,
         }
 
         # Get assembly categories for BOQ mode

--- a/templates/pages/add-building/components/building-structural-components/building-structural-components.html
+++ b/templates/pages/add-building/components/building-structural-components/building-structural-components.html
@@ -1336,7 +1336,7 @@
             <span class="badge badge-outline py-1 px-2 border-[var(--stroke--soft-200)] text-[var(--text--sub-600)]">
               ${item.category_name || i18n.noCategory}
             </span>
-            <p class="text-sm/5 text-[var(--text--sub-600)]">${item.quantity || '-'} ${item.dimension || ''}</p>
+            <p class="text-sm/5 text-[var(--text--sub-600)]">${item.quantity || '-'} ${{ area: 'm²', volume: 'm³', mass: 'kg', length: 'm', pcs: 'pcs' }[item.dimension] || item.dimension || ''}</p>
           </div>
         </div>
         <div class="flex gap-2">
@@ -1433,16 +1433,42 @@
   {% endif %}
 })();
 
-// Show a toast error when the server rejects an EPD add (e.g. unit mismatch)
+// Show an inline error on the EPD list item when the server rejects an add (e.g. unit mismatch)
 document.body.addEventListener('htmx:afterRequest', function(evt) {
+  var target = evt.detail.target;
+  var isEpdTarget = target && (target.id === 'component_materials_list' || target.id === 'structural_materials_list');
+  if (!isEpdTarget) return;
+
+  // Clear any existing inline errors in the EPD list
+  var epdList = document.getElementById('structural_epd_list');
+  if (epdList) {
+    epdList.querySelectorAll('.epd-inline-error').forEach(function(el) { el.remove(); });
+  }
+
   if (evt.detail.successful) return;
+
   var xhr = evt.detail.xhr;
   if (!xhr) return;
-  var target = evt.detail.target;
-  // Only handle errors aimed at the component or structural materials lists
-  if (target && (target.id === 'component_materials_list' || target.id === 'structural_materials_list')) {
-    var msg = (xhr.responseText || '').trim() || 'This EPD cannot be added due to a unit mismatch.';
-    if (window.Toast) Toast.error(msg, { duration: 6000 });
+
+  var msg = (xhr.responseText || '').trim() || '{% translate "This EPD cannot be added due to a unit mismatch." %}';
+
+  // Find the <li> containing the Add button that was clicked
+  var triggerBtn = evt.detail.elt;
+  var listItem = triggerBtn ? triggerBtn.closest('li') : null;
+  if (!listItem) return;
+
+  var errorEl = document.createElement('p');
+  errorEl.className = 'epd-inline-error text-xs text-[var(--state--error-base)] mt-1.5 flex items-center gap-1';
+  errorEl.innerHTML = '<span data-icon="error-warning-line" data-size="14"></span><span>' + msg + '</span>';
+
+  // Append inside the info column (alongside name and badges)
+  var infoDiv = listItem.querySelector('.flex.flex-col');
+  if (infoDiv) {
+    infoDiv.appendChild(errorEl);
+  } else {
+    listItem.appendChild(errorEl);
   }
+
+  if (window.IconComponent) window.IconComponent.initialize(errorEl);
 });
 </script>

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -444,12 +444,11 @@
           options: {
             indexAxis: "y",
             responsive: true,
-            maintainAspectRatio: true,
-            categoryPercentage: 1.0,
+            maintainAspectRatio: false,
             layout: {
               padding: {
                 left: 0,
-                right: 0,
+                right: 48,
                 top: 16,
                 bottom: 10,
               },
@@ -485,48 +484,32 @@
                 border: {
                   display: false,
                 },
+                afterFit: function(scaleInstance) {
+                  scaleInstance.width = 160;
+                },
                 ticks: {
                   color: strongTextColor,
                   font: {
-                    size: 13,
+                    size: 12,
                   },
                   padding: 12,
                   crossAlign: "far",
                   autoSkip: false,
                   callback: function (value, index, ticks) {
                     const label = this.getLabelForValue(value);
-                    const maxWidth = 84;
+                    const maxWidth = 140;
                     const ctx = this.chart.ctx;
                     ctx.font = "12px sans-serif";
 
-                    // Measure the text width
                     const textWidth = ctx.measureText(label).width;
 
                     if (textWidth > maxWidth) {
-                      // Split label into multiple lines
-                      const words = label.split(" ");
-                      const lines = [];
-                      let currentLine = "";
-
-                      words.forEach((word) => {
-                        const testLine = currentLine
-                          ? currentLine + " " + word
-                          : word;
-                        const testWidth = ctx.measureText(testLine).width;
-
-                        if (testWidth > maxWidth && currentLine) {
-                          lines.push(currentLine);
-                          currentLine = word;
-                        } else {
-                          currentLine = testLine;
-                        }
-                      });
-
-                      if (currentLine) {
-                        lines.push(currentLine);
+                      // Truncate with ellipsis instead of wrapping — keeps row height consistent
+                      let truncated = label;
+                      while (ctx.measureText(truncated + "…").width > maxWidth && truncated.length > 0) {
+                        truncated = truncated.slice(0, -1);
                       }
-
-                      return lines;
+                      return truncated + "…";
                     }
 
                     return label;
@@ -555,10 +538,12 @@
               datalabels: {
                 display: true,
                 anchor: "end",
-                align: "end",
+                align: "right",
+                offset: 4,
+                clip: false,
                 color: strongTextColor,
                 font: {
-                  size: 12,
+                  size: 11,
                   weight: "500",
                 },
                 formatter: function (value) {
@@ -567,27 +552,7 @@
               },
             },
           },
-          plugins: [
-            {
-              id: "customLabels",
-              afterDatasetsDraw: function (chart) {
-                const ctx = chart.ctx;
-                chart.data.datasets.forEach(function (dataset, i) {
-                  const meta = chart.getDatasetMeta(i);
-                  meta.data.forEach(function (bar, index) {
-                    const data = dataset.data[index];
-                    ctx.fillStyle = strongTextColor;
-                    ctx.font = "500 11px sans-serif";
-                    ctx.textAlign = "left";
-                    ctx.textBaseline = "middle";
-                    const text = data + "%";
-                    const padding = 8;
-                    ctx.fillText(text, bar.x + padding, bar.y);
-                  });
-                });
-              },
-            },
-          ],
+          plugins: [],
         };
 
         // Initialize the Embodied Carbon by Assembly bar chart
@@ -596,16 +561,19 @@
         if (embodiedCtx) {
           const assemblyData = chartData.embodied_by_assembly || { labels: [], data: [] };
 
+          const embodiedLabels = assemblyData.labels.length > 0 ? assemblyData.labels : [i18n.noData];
+          embodiedCtx.style.height = Math.max(180, embodiedLabels.length * 52) + "px";
           new Chart(embodiedCtx, {
             ...barChartDefaults,
             data: {
-              labels: assemblyData.labels.length > 0 ? assemblyData.labels : [i18n.noData],
+              labels: embodiedLabels,
               datasets: [
                 {
                   data: assemblyData.data.length > 0 ? assemblyData.data : [0],
                   backgroundColor: primaryColor,
                   borderRadius: 2,
-                  barThickness: 55,
+                  barPercentage: 0.6,
+                  categoryPercentage: 0.8,
                 },
               ],
             },
@@ -619,17 +587,20 @@
 
         if (embodiedCarbonByMaterialChart) {
           const materialData = chartData.embodied_by_material || { labels: [], data: [] };
+          const materialLabels = materialData.labels.length > 0 ? materialData.labels : [i18n.noData];
+          embodiedCarbonByMaterialChart.style.height = Math.max(180, materialLabels.length * 52) + "px";
 
           new Chart(embodiedCarbonByMaterialChart, {
             ...barChartDefaults,
             data: {
-              labels: materialData.labels.length > 0 ? materialData.labels : [i18n.noData],
+              labels: materialLabels,
               datasets: [
                 {
                   data: materialData.data.length > 0 ? materialData.data : [0],
                   backgroundColor: stateFeatureBaseColor,
                   borderRadius: 2,
-                  barThickness: 55,
+                  barPercentage: 0.6,
+                  categoryPercentage: 0.8,
                 },
               ],
             },
@@ -643,17 +614,20 @@
 
         if (embodiedCarbonByAppliancesChart) {
           const systemData = chartData.operational_by_system || { labels: [], data: [] };
+          const systemLabels = systemData.labels.length > 0 ? systemData.labels : [i18n.noData];
+          embodiedCarbonByAppliancesChart.style.height = Math.max(180, systemLabels.length * 52) + "px";
 
           new Chart(embodiedCarbonByAppliancesChart, {
             ...barChartDefaults,
             data: {
-              labels: systemData.labels.length > 0 ? systemData.labels : [i18n.noData],
+              labels: systemLabels,
               datasets: [
                 {
                   data: systemData.data.length > 0 ? systemData.data : [0],
                   backgroundColor: primaryColor,
                   borderRadius: 2,
-                  barThickness: 55,
+                  barPercentage: 0.6,
+                  categoryPercentage: 0.8,
                 },
               ],
             },


### PR DESCRIPTION
## Summary

  - **Add building flow — Step 1 locked**: Skip button hidden on Step 1 (Name & Location) and Step 1 Substep 2 (Building Details) in add mode. Go Back is disabled on Building Details so users cannot return to Name & Location once a building is created. Clicking Step 1 in the sidebar nav is blocked once a UUID exists. Navigating directly to any step beyond Step 1 without a UUID shows a guard message with links to create a new building or go to the dashboard.
  - **Fix 500 on Step 1 save**: `climate_zone` was being set to the string `'tropical-wet'` on building creation, but the field expects a `ClimateType` instance. Changed the default to `None` (field is `null=True`).
  - **EPD unit mismatch — inline error**: Replaced the toast notification with an inline error message rendered directly on the EPD list item that triggered the mismatch, so it is always visible regardless of toast z-index.
  - **Fix GWP always 0.00**: `get_gwp_impact_sum` was called with `"A1-A3"` but the stored life cycle stage key is `"a1a3"`. Fixed in both the EPD selection path and the page restore path, so component totals now calculate correctly and persist correctly after a page refresh.
  - **Fix dimension unit display**: Saved components were showing the raw dimension key (e.g. `2 area`) instead of the unit symbol. Added a mapping so it displays correctly (e.g. `2 m²`, `2 m³`, `2 kg`).
  - **Embodied carbon charts**: Removed fixed `barThickness: 55` in favour of proportional sizing. Canvas height is now dynamic based on item count so bars do not crowd. Percentage labels use `chartjs-plugin-datalabels` with `clip: false` and right padding so they are never cut off. Y-axis labels are truncated with an ellipsis at 140px instead of wrapping to multiple lines, keeping row heights consistent when there are many bars.

  ## Test plan

  - [ ] Create a new building—verify Step 1 skip button is hidden and Save & Continue is required
  - [ ] After saving Step 1, verify Go Back on Building Details is disabled and clicking Step 1 in the nav does nothing
  - [ ] Navigate directly to a later step URL without a UUID — verify guard message appears
  - [ ] Confirm Step 1 save no longer returns a 500 error
  - [ ] Add an EPD with a mismatched unit in structural components — verify inline error appears on that list item
  - [ ] Add a component with EPDs and verify GWP total is non-zero and persists after page refresh
  - [ ] Verify saved component shows e.g. `2 m²` not `2 area`
  - [ ] Open a building with multiple structural assemblies and verify chart bars scale, percentage labels are fully visible, and y-axis labels are readable