### PR TITLE
fix: multiply operational carbon by reference_period in building_stats

### DIFF
--- a/pages/views/building/building_stats.py
+++ b/pages/views/building/building_stats.py
@@ -163,10 +163,12 @@ def calculate_total_operational_carbon(building: Building, simulated: bool = Fal
     else:
         operational_products = building.operational_products.all()
 
+    reference_period = Decimal(str(building.reference_period))
+
     for op in operational_products:
         try:
             impacts = calculate_impact_operational(op)
-            total_gwp_b6 += impacts.get('gwp_b6', Decimal('0.0'))
+            total_gwp_b6 += impacts.get('gwp_b6', Decimal('0.0')) * reference_period
         except (ValueError, AttributeError, ZeroDivisionError) as e:
             # Skip products with calculation errors
             continue
@@ -428,6 +430,8 @@ def get_operational_carbon_by_system(building: Building, simulated: bool = False
     else:
         operational_products = building.operational_products.all()
 
+    reference_period = Decimal(str(building.reference_period))
+
     for op in operational_products:
         try:
             # Categorize by EPD category or use a default
@@ -451,7 +455,7 @@ def get_operational_carbon_by_system(building: Building, simulated: bool = False
                     system_type = "Gas/Fuel"
 
             impacts = calculate_impact_operational(op)
-            gwp_b6 = impacts.get('gwp_b6', Decimal('0.0'))
+            gwp_b6 = impacts.get('gwp_b6', Decimal('0.0')) * reference_period
             carbon_by_system[system_type] += gwp_b6
 
         except (ValueError, AttributeError, ZeroDivisionError):


### PR DESCRIPTION
## Summary

- `calculate_impact_operational()` returns GWP B6 in **kgCO2e/m² per year** (annual rate)
- The old dashboard (`main`) correctly multiplied this by `building.reference_period` (default: 50 years) before displaying
- The new `building_stats.py` was summing annual values without the multiplier, producing operational carbon ~50× too low (e.g. `294.3` instead of `~14,713 kgCO2eq/m²`) and a wrong total carbon footprint (`738.5` instead of `~15,158 kgCO2eq/m²`)

## Changes

- `calculate_total_operational_carbon()`: multiply each product's `gwp_b6` by `building.reference_period`
- `get_operational_carbon_by_system()`: same fix so the operational-by-system chart uses lifetime values consistent with the rest of the page

## Test plan

- [x] Load a building with operational products and verify the Operational Carbon stat matches the value previously shown in the old Plotly dashboard
- [x] Verify Total Carbon Footprint = Embodied Carbon + Operational Carbon (lifetime)
- [x] Verify Carbon Savings % is unchanged (ratio is unaffected since both simulated and actual are scaled equally)
- [x] Check the operational-by-system chart proportions are consistent