### PR TITLE
fix: align embodied carbon chart values with old dashboard by excluding negative GWP impacts

### DIFF
--- a/pages/views/building/building_stats.py
+++ b/pages/views/building/building_stats.py
@@ -142,11 +142,13 @@ def calculate_total_embodied_carbon(building: Building, simulated: bool = False)
                     p=structural_product
                 )
 
-                # Sum up GWP impacts (A1-A3)
+                # Sum up positive GWP impacts (A1-A3) only — matches old dashboard behaviour
                 for impact in impacts:
                     if impact['impact_type'].impact_category == 'gwp' and \
-                       impact['impact_type'].life_cycle_stage in ['a1a3', 'a1-a3']:
-                        total_gwp += Decimal(str(impact['impact_value']))
+                       impact['impact_type'].life_cycle_stage == 'a1a3':
+                        value = Decimal(str(impact['impact_value']))
+                        if value > 0:
+                            total_gwp += value
 
             except (ValueError, AttributeError, ZeroDivisionError) as e:
                 # Skip products with calculation errors
@@ -330,15 +332,17 @@ def get_embodied_carbon_by_assembly(building: Building, simulated: bool = False)
 
                 for impact in impacts:
                     if impact['impact_type'].impact_category == 'gwp' and \
-                       impact['impact_type'].life_cycle_stage in ['a1a3', 'a1-a3']:
-                        # Use per-product classification (same source as old dashboard)
-                        assembly_category = impact.get('assembly_category', '')
-                        if assembly_category:
-                            full_label = str(assembly_category)
-                            label = full_label.split("- ", 1)[1] if "- " in full_label else full_label
-                        else:
-                            label = assembly_name
-                        carbon_by_assembly[label] += Decimal(str(impact['impact_value']))
+                       impact['impact_type'].life_cycle_stage == 'a1a3':
+                        value = Decimal(str(impact['impact_value']))
+                        if value > 0:
+                            # Use per-product classification (same source as old dashboard)
+                            assembly_category = impact.get('assembly_category', '')
+                            if assembly_category:
+                                full_label = str(assembly_category)
+                                label = full_label.split("- ", 1)[1] if "- " in full_label else full_label
+                            else:
+                                label = assembly_name
+                            carbon_by_assembly[label] += value
 
             except (ValueError, AttributeError, ZeroDivisionError):
                 continue
@@ -402,8 +406,10 @@ def get_embodied_carbon_by_material(building: Building, simulated: bool = False)
 
                 for impact in impacts:
                     if impact['impact_type'].impact_category == 'gwp' and \
-                       impact['impact_type'].life_cycle_stage in ['a1a3', 'a1-a3']:
-                        carbon_by_material[material_category] += Decimal(str(impact['impact_value']))
+                       impact['impact_type'].life_cycle_stage == 'a1a3':
+                        value = Decimal(str(impact['impact_value']))
+                        if value > 0:
+                            carbon_by_material[material_category] += value
 
             except (ValueError, AttributeError, ZeroDivisionError):
                 continue


### PR DESCRIPTION
## Summary

- The new `building_stats.py` chart functions were summing all GWP A1-A3 impact values including negatives, while the old dashboard explicitly zeroed out negative values before summing (`df.loc[df["gwp a1a3 pos"] <= 0, "gwp a1a3 pos"] = 0`)
- This caused Foundation to appear larger than Exterior Walls in the Embodied Carbon by Assembly chart, when the correct order is Exterior Walls first (~31.8%) then Foundation (~22.2%)
- The life cycle stage filter was also checking `['a1a3', 'a1-a3']` which could double-count impacts if both variants exist — tightened to `'a1a3'` only, matching the old filter

## Changes

- `pages/views/building/building_stats.py`
  - `calculate_total_embodied_carbon()`: only accumulate positive GWP values, filter on `'a1a3'` only
  - `get_embodied_carbon_by_assembly()`: same — positive only, `'a1a3'` only
  - `get_embodied_carbon_by_material()`: same — positive only, `'a1a3'` only

## Test plan

- [ ] Embodied Carbon by Assembly chart shows Exterior Walls at ~31.8% (top), Foundation at ~22.2% (second)
- [ ] All percentages match the old tool values within rounding: Staircases ~12.5%, Beams/Slabs ~12.1%, Finishes ~10.1%, Interm. Floor ~6.5%, Miscellaneous ~2.4%, Columns ~2.4%
- [ ] Embodied Carbon by Material chart percentages are consistent with old tool
- [x] Total Embodied Carbon stat in the header is unchanged