### PR TITLE
fix: exclude unclassified assemblies from embodied carbon chart and enrich donut legend

### DIFF
--- a/pages/views/building/building_stats.py
+++ b/pages/views/building/building_stats.py
@@ -335,13 +335,12 @@ def get_embodied_carbon_by_assembly(building: Building, simulated: bool = False)
                        impact['impact_type'].life_cycle_stage == 'a1a3':
                         value = Decimal(str(impact['impact_value']))
                         if value > 0:
-                            # Use per-product classification (same source as old dashboard)
+                            # Use per-product classification — skip if no category
                             assembly_category = impact.get('assembly_category', '')
-                            if assembly_category:
-                                full_label = str(assembly_category)
-                                label = full_label.split("- ", 1)[1] if "- " in full_label else full_label
-                            else:
-                                label = assembly_name
+                            if not assembly_category:
+                                continue
+                            full_label = str(assembly_category)
+                            label = full_label.split("- ", 1)[1] if "- " in full_label else full_label
                             carbon_by_assembly[label] += value
 
             except (ValueError, AttributeError, ZeroDivisionError):

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -174,25 +174,8 @@
         <div class="grid place-items-center mt-6 w-[16.5rem] mx-auto">
           <canvas id="whole-life-carbon-cycle"></canvas>
         </div>
-        <div class="flex items-center mt-6 gap-3 justify-center">
-          <div class="flex items-center gap-2">
-            <div
-              class="size-2 rounded-full"
-              style="background-color: var(--state--feature--base)"
-            ></div>
-            <span class="text-sm text-[var(--text--sub-600)]"
-              >{% translate "Operational carbon:" %}</span
-            >
-          </div>
-          <div class="flex items-center gap-2">
-            <div
-              class="size-2 rounded-full"
-              style="background-color: var(--bg--surface-800)"
-            ></div>
-            <span class="text-sm text-[var(--text--sub-600)]"
-              >{% translate "Embodied carbon:" %}</span
-            >
-          </div>
+        <div class="flex justify-center mt-6">
+          <div id="whole-life-legend" class="flex flex-col gap-2"></div>
         </div>
       </div>
       <div
@@ -449,6 +432,23 @@
             },
             plugins: [ChartDataLabels],
           });
+
+          // Build legend: colour dot + label name + carbon value
+          const legendEl = document.getElementById("whole-life-legend");
+          if (legendEl) {
+            const colors = [operationalColor, embodiedColor];
+            wholeLifeData.labels.forEach(function (lbl, i) {
+              const value = wholeLifeData.data[i];
+              const formatted = value.toLocaleString("en-US", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+              const row = document.createElement("div");
+              row.className = "flex items-center gap-2";
+              row.innerHTML = `
+                <div class="size-2 rounded-full flex-shrink-0" style="background-color:${colors[i]}"></div>
+                <span class="text-sm text-[var(--text--sub-600)]">${lbl}: ${formatted} kgCO₂eq/m²</span>
+              `;
+              legendEl.appendChild(row);
+            });
+          }
         }
 
         function makeBarChart(chartLabels, percentData, absoluteData, barColor) {


### PR DESCRIPTION
## Summary

- Assemblies without a classification category are now excluded from the Embodied Carbon by Assembly chart entirely, per updated requirements (previously they appeared as a named bar using the assembly name)
- The Whole Life Carbon Cycle donut legend now shows each slice's name alongside its absolute carbon value (e.g. "Operational carbon: 0.1 kgCO₂eq/m²"), matching the old tool's level of detail, replacing the previous label-only legend

## Changes

- `pages/views/building/building_stats.py`
  - `get_embodied_carbon_by_assembly()`: skip any impact whose `assembly_category` is empty instead of falling back to `assembly_name`
- `templates/pages/building/building.html`
  - Replace static HTML legend with a JS-built legend that renders label + formatted carbon value per slice, centred under the donut chart

## Test plan

- [x] Assemblies with no classification do not appear in the Embodied Carbon by Assembly chart
- [x] Donut legend shows both slices with their carbon values in kgCO₂eq/m²
- [x] Legend is visually centred under the donut with both bullet points aligned to the same left edge
- [x] Donut slice percentages still display correctly inside each slice