### PR TITLE
Fix: Saving building details step fails with "Invalid building UUID" 

### DIFF
--- a/pages/views/building/add_building_steps.py
+++ b/pages/views/building/add_building_steps.py
@@ -626,12 +626,17 @@ def save_building_step(request):
                     uuid_obj = uuid_lib.UUID(building_uuid)
                     building = Building.objects.get(uuid=uuid_obj, created_by=request.user)
 
-                    # Map form field names to model field names
+                    # Resolve climate_zone FK before generic field mapping
+                    if step_data.get('climate_type'):
+                        try:
+                            building.climate_zone = ClimateType.objects.get(name=step_data['climate_type'])
+                        except ClimateType.DoesNotExist:
+                            pass
+
+                    # Map remaining form field names to model field names
                     field_mapping = {
-                        'climate_type': 'climate_zone',
                         'assessment_period': 'reference_period',
                         'conditioned_floor_area': 'cond_floor_area',
-                        # Direct mappings (same name)
                         'construction_year': 'construction_year',
                         'total_floor_area': 'total_floor_area',
                         'floors_below_ground': 'floors_below_ground',
@@ -660,8 +665,11 @@ def save_building_step(request):
                     building.save()
                     building_uuid = str(building.uuid)
 
-                except (ValueError, Building.DoesNotExist):
-                    return JsonResponse({"error": "Invalid building UUID"}, status=400)
+                except Building.DoesNotExist:
+                    return JsonResponse({"error": "Building not found"}, status=404)
+                except ValueError as e:
+                    logger.exception(f"Error updating building details: {e}")
+                    return JsonResponse({"error": str(e)}, status=400)
             else:
                 return JsonResponse({"error": "Building must be created in step 1.1 first"}, status=400)
 


### PR DESCRIPTION
### Problem

  Saving step 1.2 (Building Details) in the add/edit building wizard returned a 400 "Invalid building UUID" error even
  when the UUID in the payload was valid and the building existed.

  The root cause was in `save_building_step` for the `building-information/building-details` step. The field mapping
  included `climate_type → climate_zone`, and the code did:

      setattr(building, 'climate_zone', 'warm-humid')

  `climate_zone` is a ForeignKey to `ClimateType`, so assigning a raw string raises a `ValueError` on `building.save()`.
   This ValueError was caught by `except (ValueError, Building.DoesNotExist)` and returned as the misleading "Invalid
  building UUID" message.

  ### Fix

  - Resolve `climate_type` to a `ClimateType` instance via `ClimateType.objects.get(name=...)` before the generic field
  mapping loop, instead of treating it as a plain string assignment.
  - Removed `climate_type` from the generic field mapping dict so it is no longer processed there.
  - Separated `Building.DoesNotExist` and `ValueError` into distinct except blocks with accurate error messages so
  future errors are easier to diagnose.

  ### Testing

  - Step 1.2 save now completes successfully and persists climate zone, building type, apartment type, floor area, and
  all other fields correctly.