### PR TITLE
feat: import Thailand TGO CFP EPDs

### DIFF
--- a/pages/management/commands/load_thailand_epds.py
+++ b/pages/management/commands/load_thailand_epds.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from pages.scripts.csv_import.import_thailand_epds import import_thailand_epds
+
+
+class Command(BaseCommand):
+    help = "Load Thailand TGO CFP EPDs from docs/TH_CFP-TGO_Data_final(18Feb2026).xlsx"
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        self.stdout.write(self.style.SUCCESS("Starting Thailand TGO EPD import..."))
+        import_thailand_epds()
+        self.stdout.write(self.style.SUCCESS("Done."))

--- a/pages/scripts/csv_import/import_thailand_epds.py
+++ b/pages/scripts/csv_import/import_thailand_epds.py
@@ -1,0 +1,165 @@
+import re
+import uuid
+import logging
+import openpyxl
+
+from cities_light.models import Country
+
+from pages.models.epd import EPD, EPDImpact, EPDType, Impact, Unit
+from pages.scripts.csv_import.utils import get_superuser
+
+logger = logging.getLogger(__name__)
+
+FILE_PATH = "docs/TH_CFP-TGO_Data_final(18Feb2026).xlsx"
+SOURCE = "TGO"
+
+UNIT_MAP = {
+    "m2": Unit.M2,
+    "m3": Unit.M3,
+    "kg": Unit.KG,
+    "m": Unit.M,
+    "pcs": Unit.PCS,
+    "ton": Unit.TONES,
+    "hour": Unit.UNKNOWN,
+    "gallon": Unit.UNKNOWN,
+}
+
+
+def parse_cf_volume(raw):
+    """
+    Parse strings like '268 gCO2e', '22.5 kgCO2e', or '14.6 kg'.
+    Returns (value_in_kg, True) or (None, False) if unparseable/null.
+    gCO2e values are divided by 1000 to convert to kgCO2e.
+    Bare 'kg' values are treated as kgCO2e.
+    """
+    if not raw:
+        return None, False
+    raw = str(raw).strip()
+    match = re.match(r"^([\d.]+)\s*(g|kg)(?:CO2e)?$", raw, re.IGNORECASE)
+    if not match:
+        return None, False
+    value = float(match.group(1))
+    if match.group(2).lower() == "g":
+        value = value / 1000
+    return value, True
+
+
+def map_unit(raw_unit):
+    if not raw_unit or str(raw_unit).strip() in ("0", "None", ""):
+        return Unit.UNKNOWN
+    return UNIT_MAP.get(str(raw_unit).strip().lower(), Unit.UNKNOWN)
+
+
+def import_thailand_epds():
+    superuser = get_superuser()
+
+    try:
+        country = Country.objects.get(name="Thailand")
+    except Country.DoesNotExist:
+        logger.error("Country 'Thailand' not found in database. Aborting.")
+        return
+
+    try:
+        wb = openpyxl.load_workbook(FILE_PATH, read_only=True, data_only=True)
+        ws = wb["Data"]
+    except Exception as e:
+        logger.error("Failed to open Excel file: %s", e)
+        return
+
+    gwp_impact, _ = Impact.objects.get_or_create(
+        impact_category="gwp",
+        life_cycle_stage="a1a3",
+    )
+
+    skipped_excluded = 0    # unit status != Good
+    skipped_no_unit = 0     # blank declared unit
+    skipped_no_name = 0     # blank English name
+    imported_with_gwp = 0   # EPD + GWP impact created
+    imported_no_gwp = 0     # EPD created, CF Volume null so no impact
+    failure = 0
+    failure_rows = []
+
+    for row_idx, row in enumerate(ws.iter_rows(min_row=2, values_only=True), start=2):
+        if all(v is None for v in row):
+            break
+        if len(row) < 26:
+            continue
+
+        try:
+            unit_status = row[1]           # col B
+            declared_unit_raw = row[2]     # col C
+            declared_amount_raw = row[3]   # col D
+            name = row[21]                 # col V - English name
+            cf_volume_raw = row[25]        # col Z
+
+            if str(unit_status).strip().lower() != "good":
+                skipped_excluded += 1
+                continue
+
+            if not name or str(name).strip() == "":
+                skipped_no_name += 1
+                continue
+
+            if not declared_unit_raw or str(declared_unit_raw).strip() in ("", "0", "None"):
+                skipped_no_unit += 1
+                continue
+
+            name = str(name).strip()
+            declared_unit = map_unit(declared_unit_raw)
+
+            try:
+                declared_amount = float(declared_amount_raw) if declared_amount_raw not in (None, "", "0", 0) else 1.0
+                if declared_amount <= 0:
+                    declared_amount = 1.0
+            except (ValueError, TypeError):
+                declared_amount = 1.0
+
+            epd, _ = EPD.objects.update_or_create(
+                name=name,
+                country=country,
+                source=SOURCE,
+                defaults={
+                    "UUID": str(uuid.uuid4()),
+                    "names": [{"lang": "en", "value": name}],
+                    "type": EPDType.OFFICIAL_NON_STANDARD,
+                    "declared_unit": declared_unit,
+                    "declared_amount": declared_amount,
+                    "public": True,
+                    "created_by_id": superuser.id,
+                    "conversions": [],
+                },
+            )
+
+            gwp_value, parseable = parse_cf_volume(cf_volume_raw)
+            if parseable:
+                EPDImpact.objects.update_or_create(
+                    epd=epd,
+                    impact=gwp_impact,
+                    defaults={"value": gwp_value},
+                )
+                imported_with_gwp += 1
+            else:
+                imported_no_gwp += 1
+                logger.info(
+                    "Row %d: '%s' imported without GWP impact — CF Volume null/unparseable: %r",
+                    row_idx, name, cf_volume_raw,
+                )
+
+        except Exception as e:
+            logger.exception("Row %d: unexpected error — %s", row_idx, e)
+            failure += 1
+            failure_rows.append(row_idx)
+
+    wb.close()
+
+    total_imported = imported_with_gwp + imported_no_gwp
+    print(f"\n{'='*60}")
+    print(f"Thailand TGO EPD import complete.")
+    print(f"  Skipped (Unit status != Good):  {skipped_excluded}")
+    print(f"  Skipped (blank declared unit):  {skipped_no_unit}")
+    print(f"  Skipped (missing name):         {skipped_no_name}")
+    print(f"  Total EPDs imported:            {total_imported}")
+    print(f"    - with GWP impact:            {imported_with_gwp}")
+    print(f"    - without GWP impact:         {imported_no_gwp}  (CF Volume null — EPDImpact.value does not allow null)")
+    print(f"  Failed rows (errors):           {failure}  {failure_rows if failure_rows else ''}")
+    print(f"{'='*60}\n")


### PR DESCRIPTION
### Summary

  - Adds `pages/scripts/csv_import/import_thailand_epds.py` — import logic that reads the `Data` tab of
  `docs/TH_CFP-TGO_Data_final(18Feb2026).xlsx`
  - Adds `pages/management/commands/load_thailand_epds.py` — management command `python manage.py load_thailand_epds`

  ### Column mapping

  | Excel Column | Header | → Model Field |
  |---|---|---|
  | V | Name (English) | `EPD.name` / `EPD.names` |
  | C | declared_unit | `EPD.declared_unit` |
  | D | declared_amount | `EPD.declared_amount` |
  | Z | CF Volume | `EPDImpact.value` (gwp, a1a3) |

  - Column K (Thai name ชื่อ) is ignored — no translated name field in the model
  - `EPD.source` = `"TGO"`, `EPD.country` = Thailand, `EPD.type` = `OFFICIAL_NON_STANDARD`
  - CF Volume is a mixed string (`"268 gCO2e"` / `"22 kgCO2e"`) — values in `gCO2e` are divided by 1000 to convert to `kgCO2e` before storing. Bare `kg` values (e.g. `"14.6 kg"`) are also treated as `kgCO2e`.

  ### Filtering logic

  Only rows where **Unit status (col B) = `Good`** are imported. Rows marked `Excluded` or blank are skipped entirely.

  ### Import results (run on 2026-04-29)

  | | Count |
  |---|---|
  | Skipped — Unit status != Good | 924 |
  | Skipped — missing English name (col V) | 18 |
  | **Total EPDs imported** | **3,578** |
  | — with GWP impact | 3,401 |
  | — without GWP impact | 177 |
  | Failed rows (errors) | 0 |

  ### Notes for review

  - **177 EPDs were imported without a GWP impact value** because their CF Volume (col Z) was null. `EPDImpact.value` is a plain `FloatField()` with no `null=True` — it cannot store null — so the `EPDImpact` record is skipped for these rows while the `EPD` record is still created. **Please confirm** whether EPDs without an impact value should be excluded entirely (i.e. skip both the EPD and the impact if CF Volume is null), or kept as-is.
  - **Certificate No. (col J)** is not mapped to any model field — 456 rows have no certificate number, making it unsuitable as a unique identifier. A new UUID is generated for each EPD instead.
  - The `Data` tab contains rows marked `Unusable` in col A — these are covered by the `Unit status != Good` filter and are not imported.

  ### Test plan

  - [x] Run `python manage.py load_thailand_epds` 
  - [x] Verify EPD count matches expected (~3,578)
  - [x] Spot-check a `gCO2e` row to confirm conversion to `kgCO2e` (e.g. `268 gCO2e` → `0.268`)
  - [x] Confirm all imported EPDs have `country=Thailand`, `source=TGO`, `type=official_non_standard`
