### PR TITLE
fix: display GCCA cement label logo in new UI EPD search

### DIFF
--- a/templates/pages/add-building/components/building-structural-components/_epd_list.html
+++ b/templates/pages/add-building/components/building-structural-components/_epd_list.html
@@ -1,4 +1,6 @@
 {% load i18n %}
+{% load static %}
+{% load custom_filters %}
 <ul class="flex flex-col gap-2">
   {% for epd in epd_list %}
   <li class="py-2.5 flex items-center justify-between gap-2.5 not-last:border-b border-[var(--stroke--soft-200)]">
@@ -20,6 +22,18 @@
         <span class="badge badge-outline py-1 px-2 border-[var(--stroke--soft-200)] text-[var(--text--sub-600)]">
           {{ epd.impact_gwp|floatformat:2 }} kgCO2eq/{{ epd.declared_unit }}
         </span>
+        {% with label=epd.labels|get_item:"GCCA Global Reference Threshold Low Carbon and Near Zero Emissions Concrete" %}
+          {% if label %}
+            {% with image_path='images/svg/GCCA_label_'|add:label|add:'.svg' %}
+              <img
+                src="{% static image_path %}"
+                alt="GCCA label {{ label }}"
+                title="GCCA label {{ label }}"
+                height="30"
+              >
+            {% endwith %}
+          {% endif %}
+        {% endwith %}
       </div>
     </div>
     <div class="flex flex-col items-end gap-2.5 shrink-0">

--- a/templates/pages/add-building/components/operational-data-entry/_epd_list.html
+++ b/templates/pages/add-building/components/operational-data-entry/_epd_list.html
@@ -1,5 +1,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load static %}
+{% load custom_filters %}
 
 <ul class="flex flex-col gap-2">
     {% for epd in epd_list %}
@@ -45,6 +47,18 @@
                   class="badge badge-outline py-1 px-2 border-[var(--stroke--soft-200)] text-[var(--text--sub-600)]"
                   >{{ epd.impact_gwp|floatformat:"-2" }}  kgO₂eq</span
                 >
+                {% with label=epd.labels|get_item:"GCCA Global Reference Threshold Low Carbon and Near Zero Emissions Concrete" %}
+                  {% if label %}
+                    {% with image_path='images/svg/GCCA_label_'|add:label|add:'.svg' %}
+                      <img
+                        src="{% static image_path %}"
+                        alt="GCCA label {{ label }}"
+                        title="GCCA label {{ label }}"
+                        height="30"
+                      >
+                    {% endwith %}
+                  {% endif %}
+                {% endwith %}
               </div>
             </div>
             <button


### PR DESCRIPTION
  ## Summary

  - The GCCA cement label logo (A–G SVG badges) was not appearing in the EPD search results of the new UI flow
  (structural components and operational data entry steps)
  - Added `{% load static %}` and `{% load custom_filters %}` to both new UI EPD list templates
  - Added the GCCA label logo block (identical to the existing `assembly/epd_list.html` implementation) to the badges
  row in each template

  ## Root cause

  The two new-UI-flow partials (`building-structural-components/_epd_list.html` and
  `operational-data-entry/_epd_list.html`) were written without the logo block that exists in the legacy
  `assembly/epd_list.html`. The backend already correctly prefetches and exposes `epd.labels` as a dict via
  `prefetch_epds` — only the template rendering was missing.

  ## Test plan

  - [x] Search for "JSW" in the structural components EPD search — JSW M 20–50 RMC entries should show GCCA label logos
  (scores C, D, F)
  - [x] Search for "Ready-mix concrete" — entries should show GCCA label logos (scores D, E, G)
  - [x] Verify logo does not appear for non-concrete EPDs
  - [x] Verify both structural and operational EPD search modals show logos correctly