### PR TITLE
fix: resize GCCA label logo to 10px across all EPD search templates

### DIFF
--- a/templates/pages/add-building/components/building-structural-components/_epd_list.html
+++ b/templates/pages/add-building/components/building-structural-components/_epd_list.html
@@ -29,7 +29,7 @@
                 src="{% static image_path %}"
                 alt="GCCA label {{ label }}"
                 title="GCCA label {{ label }}"
-                height="30"
+                height="10"
               >
             {% endwith %}
           {% endif %}

--- a/templates/pages/add-building/components/operational-data-entry/_epd_list.html
+++ b/templates/pages/add-building/components/operational-data-entry/_epd_list.html
@@ -54,7 +54,7 @@
                         src="{% static image_path %}"
                         alt="GCCA label {{ label }}"
                         title="GCCA label {{ label }}"
-                        height="30"
+                        height="10"
                       >
                     {% endwith %}
                   {% endif %}

--- a/templates/pages/assembly/epd_list.html
+++ b/templates/pages/assembly/epd_list.html
@@ -45,7 +45,7 @@
                                     src="{% static image_path %}"
                                     alt="GCCA label {{ label }}"
                                     title="GCCA label {{ label }}"
-                                    height="30"
+                                    height="10"
                                 >
                             {% endwith %}
                         {% endif %}


### PR DESCRIPTION
## Summary

  - Resized GCCA cement label logo from 30px to 10px across all three EPD search templates
  - Affected templates: `assembly/epd_list.html`, `building-structural-components/_epd_list.html`,
  `operational-data-entry/_epd_list.html`

  ## Test plan

  - [x] Open EPD search in the assembly/BOQ (edit building flow) and confirm GCCA logo appears at the smaller size
  - [x] Open EPD search in the structural components step (add building flow) and confirm logo size
  - [x] Open EPD search in the operational data entry step and confirm logo size