### PR TITLE
fix: QA feedback — layers unit, GCCA logo, EPD link, unit casing, select   styling

### DIFF
--- a/pages/templatetags/custom_filters.py
+++ b/pages/templatetags/custom_filters.py
@@ -30,3 +30,13 @@ def get_step(selection_unit):
 def get_item(dictionary, key):
     return dictionary.get(key)
 
+
+_UNIT_DISPLAY = {
+    "kwh": "kWh",
+}
+
+@register.filter(is_safe=True)
+@stringfilter
+def display_unit(value):
+    return _UNIT_DISPLAY.get(value, value)
+

--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -305,6 +305,7 @@ def handle_select_product(request):
             "timestamp": datetime.now().strftime("%Y%m%d%H%M%S%f"),
             "available_units": available_units,
             "gwp": epd.get_gwp_impact_sum("a1a3") or 0,
+            "source": epd.source or "",
         }
 
         # Get assembly categories for BOQ mode

--- a/templates/pages/add-building/components/building-structural-components/_epd_list.html
+++ b/templates/pages/add-building/components/building-structural-components/_epd_list.html
@@ -38,7 +38,7 @@
       </div>
     </div>
     <div class="flex flex-col items-end gap-2.5 shrink-0">
-      {% if epd.source %}
+      {% if epd.source and epd.source|slice:":4" == "http" %}
       <a href="{{ epd.source }}" target="_blank" rel="noopener">
         <span data-icon="external-link-line" data-size="20" data-color="var(--icon--sub-600)"></span>
       </a>

--- a/templates/pages/add-building/components/building-structural-components/_epd_list.html
+++ b/templates/pages/add-building/components/building-structural-components/_epd_list.html
@@ -29,7 +29,8 @@
                 src="{% static image_path %}"
                 alt="GCCA label {{ label }}"
                 title="GCCA label {{ label }}"
-                height="10"
+                height="25"
+                width="54"
               >
             {% endwith %}
           {% endif %}
@@ -38,7 +39,7 @@
     </div>
     <div class="flex flex-col items-end gap-2.5 shrink-0">
       {% if epd.source %}
-      <a class='hidden' href="{{ epd.source }}" target="_blank" rel="noopener">
+      <a href="{{ epd.source }}" target="_blank" rel="noopener">
         <span data-icon="external-link-line" data-size="20" data-color="var(--icon--sub-600)"></span>
       </a>
       {% endif %}

--- a/templates/pages/add-building/components/building-structural-components/_selected_material.html
+++ b/templates/pages/add-building/components/building-structural-components/_selected_material.html
@@ -9,7 +9,7 @@
         <span class="text-sm/5 font-medium truncate flex-1">{{ epd.name|truncatechars:50 }}</span>
         <div class="flex items-center gap-2">
           <span data-country="{{ epd.country }}" data-width="16"></span>
-          {% if epd.source %}
+          {% if epd.source and epd.source|slice:":4" == "http" %}
           <a href="{{ epd.source }}" target="_blank" rel="noopener">
             <span data-icon="external-link-line" data-size="20" data-color="var(--icon--sub-600)"></span>
           </a>

--- a/templates/pages/add-building/components/building-structural-components/_selected_material.html
+++ b/templates/pages/add-building/components/building-structural-components/_selected_material.html
@@ -9,9 +9,11 @@
         <span class="text-sm/5 font-medium truncate flex-1">{{ epd.name|truncatechars:50 }}</span>
         <div class="flex items-center gap-2">
           <span data-country="{{ epd.country }}" data-width="16"></span>
-          <a href="#" target="_blank" rel="noopener">
+          {% if epd.source %}
+          <a href="{{ epd.source }}" target="_blank" rel="noopener">
             <span data-icon="external-link-line" data-size="20" data-color="var(--icon--sub-600)"></span>
           </a>
+          {% endif %}
         </div>
       </div>
 
@@ -42,7 +44,7 @@
             min="0"
             class="material-quantity"
             required />
-      <span class="text-xs text-[var(--text--sub-600)] material-unit" data-unit="{{ epd.selection_unit }}">{% if epd.selection_unit == 'unknown' %}#{% else %}{{ epd.selection_unit }}{% endif %}</span>
+      <span class="text-xs text-[var(--text--sub-600)] material-unit" data-unit="{{ epd.selection_unit }}">{% if epd.selection_unit == 'unknown' %}layers{% else %}{{ epd.selection_unit }}{% endif %}</span>
       <input type="hidden" class="material-unit-value" value="{{ epd.selection_unit }}" />
     </label>
 

--- a/templates/pages/add-building/components/operational-data-entry/_epd_list.html
+++ b/templates/pages/add-building/components/operational-data-entry/_epd_list.html
@@ -45,7 +45,7 @@
                 >
                 <span
                   class="badge badge-outline py-1 px-2 border-[var(--stroke--soft-200)] text-[var(--text--sub-600)]"
-                  >{{ epd.impact_gwp|floatformat:"-2" }}  kgO₂eq</span
+                  >{{ epd.impact_gwp|floatformat:"-2" }} kgCO₂eq</span
                 >
                 {% with label=epd.labels|get_item:"GCCA Global Reference Threshold Low Carbon and Near Zero Emissions Concrete" %}
                   {% if label %}
@@ -54,7 +54,8 @@
                         src="{% static image_path %}"
                         alt="GCCA label {{ label }}"
                         title="GCCA label {{ label }}"
-                        height="10"
+                        height="25"
+                        width="54"
                       >
                     {% endwith %}
                   {% endif %}

--- a/templates/pages/add-building/components/operational-data-entry/_epd_list.html
+++ b/templates/pages/add-building/components/operational-data-entry/_epd_list.html
@@ -20,7 +20,7 @@
                     data-color="var(--icon--soft-400)"
                   ></span>
                   <span class="text-[var(--text--sub-600)]">
-                    {% if epd.type == "official" %}
+                    {% if epd.type == "official" and epd.source|slice:":4" == "http" %}
                     <a href="{{ epd.source }}"
                        target="_blank"
                        rel="noopener noreferrer"

--- a/templates/pages/add-building/components/operational-data-entry/_selected_product.html
+++ b/templates/pages/add-building/components/operational-data-entry/_selected_product.html
@@ -37,7 +37,7 @@
                 min="1"
                 step="0.01" />
               {% if epd.op_units|length > 1 %}
-              <select name="material_{{ epd.id }}_unit_{{ epd.timestamp }}" class="select select-ghost focus:!outline-none !pr-0 rounded-none w-[calc(max-content+1rem)]">
+              <select name="material_{{ epd.id }}_unit_{{ epd.timestamp }}" class="select focus:!outline-none !pr-0 rounded-none border-l border-[var(--stroke--soft-200)]">
                 {% for unit in epd.op_units %}
                 <option value="{{ unit }}" {% if unit == epd.selection_unit %}selected{% endif %}>{{ unit|display_unit }}</option>
                 {% endfor %}

--- a/templates/pages/add-building/components/operational-data-entry/_selected_product.html
+++ b/templates/pages/add-building/components/operational-data-entry/_selected_product.html
@@ -39,11 +39,11 @@
               {% if epd.op_units|length > 1 %}
               <select name="material_{{ epd.id }}_unit_{{ epd.timestamp }}" class="select select-ghost focus:!outline-none !pr-0 rounded-none w-[calc(max-content+1rem)]">
                 {% for unit in epd.op_units %}
-                <option value="{{ unit }}" {% if unit == epd.selection_unit %}selected{% endif %}>{{ unit }}</option>
+                <option value="{{ unit }}" {% if unit == epd.selection_unit %}selected{% endif %}>{{ unit|display_unit }}</option>
                 {% endfor %}
               </select>
               {% else %}
-              <span class="text-sm/5 align-middle text-[var(--text--sub-600)] pr-3">{{ epd.selection_unit }}</span>
+              <span class="text-sm/5 align-middle text-[var(--text--sub-600)] pr-3">{{ epd.selection_unit|display_unit }}</span>
               <input type="hidden" name="material_{{ epd.id }}_unit_{{ epd.timestamp }}" value="{{ epd.selection_unit }}" />
               {% endif %}
             </label>


### PR DESCRIPTION
  ## Summary

  - **# symbol on layers field**: When adding an m² EPD to an area (m²) component, the quantity unit now shows `layers` instead of `#`
  - **GCCA cement logo size**: Fixed oversized logo by setting explicit
  `height`/`width` on the `<img>` tag in both structural and operational EPD search lists
  - **EPD external link reinstated**: The external link icon now appears in both the EPD search list and the selected material row; link is only shown when the source is a valid URL (guards against internal identifiers like `GFA-HEAT` that were causing navigation to `/building/GFA-HEAT`)
  - **Unit casing — kgCO₂eq**: Fixed `kgO₂eq` → `kgCO₂eq` in the operational EPD search list
  - **Unit casing — kWh**: Added a `display_unit` template filter that renders
  the stored `kwh` value as `kWh` in the energy carrier quantity field
  - **Energy carrier unit select**: Removed `select-ghost` class so the unit dropdown is visible instead of transparent

  ## Files changed

  - `pages/templatetags/custom_filters.py` — added `display_unit` filter
  - `pages/views/building/building_step_structural.py` — added `source` to EPD
  data dict
  - `templates/pages/add-building/components/building-structural-components/_epd_list.html`
  - `templates/pages/add-building/components/building-structural-components/_selected_material.html`
  - `templates/pages/add-building/components/operational-data-entry/_epd_list.html`
  - `templates/pages/add-building/components/operational-data-entry/_selected_product.html`