### PR TITLE
fix: restrict structural template selection to own and system templates only

### DIFF
--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -683,9 +683,9 @@ def handle_search_templates(request):
     Search and filter templates (assemblies) for selection in building structural components.
     Reuses logic from templates view with same filters.
     """
-    # Start with base queryset - show public assemblies and user's custom assemblies
+    # Show public assemblies from staff/superusers (system defaults) and user's own assemblies
     assemblies = Assembly.objects.filter(
-        Q(public=True) | Q(created_by=request.user),
+        Q(public=True, created_by__is_staff=True) | Q(public=True, created_by__is_superuser=True) | Q(created_by=request.user),
         draft=False,
         is_boq=False,  # Exclude Bill of Quantities
     )

--- a/pages/views/templates.py
+++ b/pages/views/templates.py
@@ -20,9 +20,9 @@ def templates(request):
     Display reusable assembly templates with search and filter functionality.
     Handles both full page load and HTMX partial updates.
     """
-    # Start with base queryset - show public assemblies and user's custom assemblies
+    # Show public assemblies from staff/superusers (system defaults) and user's own assemblies
     assemblies = Assembly.objects.filter(
-        Q(public=True) | Q(created_by=request.user),
+        Q(public=True, created_by__is_staff=True) | Q(public=True, created_by__is_superuser=True) | Q(created_by=request.user),
         draft=False,
         is_boq=False,  # Exclude Bill of Quantities
     )


### PR DESCRIPTION
## Description

  When selecting a structural component template ("Select from default") during building add/edit, the template list was
   showing public assemblies created by **all users**, not just the current user's own templates.



## Behaviour after fix

  - **System/default templates** — public assemblies created by staff or superusers are shown to all users (intended system defaults)
  - **Custom templates** — only assemblies created by the logged-in user are shown; other users' assemblies are never
  visible

## Testing

  1. Create a template as User A and mark it public (via admin)
  2. Log in as User B — the template should **not** appear in the structural component selector
  3. Log in as a staff/superuser, create a public template — it **should** appear for all users