### PR TITLE
feat: AI-generated report narratives, cookie-based export polling, edit building title fix

### DIFF
--- a/pages/views/building/building_report.py
+++ b/pages/views/building/building_report.py
@@ -1,8 +1,11 @@
 import base64
 import io
+import json
+import logging
 import os
 from datetime import date
 
+from openai import OpenAI
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
@@ -10,7 +13,104 @@ from django.conf import settings
 from django.views.decorators.http import require_http_methods
 
 from pages.models.building import Building
-from pages.views.building.building_stats import get_building_detail_statistics, get_building_chart_data
+from pages.views.building.building_stats import (
+    get_building_detail_statistics,
+    get_building_chart_data,
+    get_embodied_carbon_by_assembly,
+    get_embodied_carbon_by_material,
+    get_operational_carbon_by_system,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data):
+    """
+    Call GPT-4o-mini once with all building data and return a dict of AI-generated
+    narrative sections for the report. Returns None if the API call fails.
+    """
+    api_key = os.environ.get("REPORT_API_KEY", "")
+    if not api_key:
+        return None
+
+    total = float(stats["total_carbon_footprint"])
+    embodied = float(stats["total_embodied_carbon"])
+    operational = float(stats["total_operational_carbon"])
+    op_pct = round(operational / total * 100) if total else 0
+    em_pct = round(embodied / total * 100) if total else 0
+
+    # Build readable breakdowns
+    assembly_lines = ", ".join(
+        f"{l}: {p}% ({a} kgCO₂eq/m²)"
+        for l, p, a in zip(assembly_data["labels"], assembly_data["data"], assembly_data["absolute"])
+    ) or "No assembly data"
+
+    material_lines = ", ".join(
+        f"{l}: {p}% ({a} kgCO₂eq/m²)"
+        for l, p, a in zip(material_data["labels"], material_data["data"], material_data["absolute"])
+    ) or "No material data"
+
+    operational_lines = ", ".join(
+        f"{l}: {p}% ({a} kgCO₂eq/m²)"
+        for l, p, a in zip(operational_data["labels"], operational_data["data"], operational_data["absolute"])
+    ) or "No operational data"
+
+    cat = subcat = ""
+    if building.category:
+        cat = str(building.category.category) if building.category.category else ""
+        subcat = str(building.category.subcategory) if building.category.subcategory else ""
+
+    prompt = f"""You are a sustainability analyst writing a Whole Life Carbon Assessment Report for a building.
+Generate concise, professional narrative text for 5 specific report sections based on the real building data below.
+
+BUILDING DATA:
+- Name: {building.name}
+- Country: {building.country}
+- Region: {building.region or "N/A"}
+- Building type: {cat} / {subcat}
+- Climate zone: {building.climate_zone or "N/A"}
+- Total floor area: {building.total_floor_area} m²
+- Assessment period: {building.reference_period} years
+- Construction year: {building.construction_year or "N/A"}
+
+CARBON DATA:
+- Total carbon footprint: {total:.1f} kgCO₂eq/m²
+- Embodied carbon: {embodied:.1f} kgCO₂eq/m² ({em_pct}% of total)
+- Operational carbon: {operational:.1f} kgCO₂eq/m² ({op_pct}% of total)
+
+EMBODIED CARBON BY ASSEMBLY: {assembly_lines}
+EMBODIED CARBON BY MATERIAL: {material_lines}
+OPERATIONAL CARBON BY SYSTEM: {operational_lines}
+
+Return ONLY a valid JSON object with exactly these 5 keys. No markdown, no code blocks, just raw JSON:
+
+{{
+  "section_2_narrative": "2-3 sentence paragraph interpreting the operational vs embodied carbon split for this specific building. Reference the actual percentages and values.",
+  "section_3_material_insight": "2-3 sentence paragraph identifying the dominant materials driving embodied carbon for this building and recommending specific reduction strategies based on the actual material breakdown.",
+  "section_4_operational_insight": "1-2 sentence paragraph identifying the dominant operational carbon system(s) for this building based on the actual system breakdown.",
+  "section_5_benchmark_callout": "1-2 sentence callout noting the building's total carbon footprint and what it means relative to typical buildings of this type in this region. Be specific to the building's country and type.",
+  "section_5_strategies": [
+    {{"material": "material name", "saving": "estimated saving description with numbers"}},
+    {{"material": "material name", "saving": "estimated saving description with numbers"}},
+    {{"material": "Total potential saving", "saving": "total summary"}}
+  ]
+}}
+
+For section_5_strategies, generate 2-3 rows based on the top materials from the actual material breakdown, plus a totals row. Use realistic saving estimates (10-30% reduction) based on the actual values."""
+
+    try:
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+            response_format={"type": "json_object"},
+            timeout=30,
+        )
+        return json.loads(response.choices[0].message.content)
+    except Exception as exc:
+        logger.warning("AI narrative generation failed: %s", exc)
+        return None
 
 
 def _get_logo_b64(filename):
@@ -113,6 +213,12 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
     leaf_icon = _get_icon_b64("leaf-line.svg")
     donut_card = _donut_card_html(operational, embodied, leaf_icon, card_donut)
 
+    assembly_data = get_embodied_carbon_by_assembly(building)
+    material_data = get_embodied_carbon_by_material(building)
+    operational_data = get_operational_carbon_by_system(building)
+
+    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data) or {}
+
     def fmt(val):
         return f"{val:,.1f}"
 
@@ -138,6 +244,12 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
         "card_assembly": card_assembly,
         "card_material": card_material,
         "card_savings": card_savings,
+        # AI-generated narratives (fall back to None if generation failed)
+        "ai_section_2_narrative": ai.get("section_2_narrative"),
+        "ai_section_3_material_insight": ai.get("section_3_material_insight"),
+        "ai_section_4_operational_insight": ai.get("section_4_operational_insight"),
+        "ai_section_5_benchmark_callout": ai.get("section_5_benchmark_callout"),
+        "ai_section_5_strategies": ai.get("section_5_strategies"),
     }
 
 
@@ -383,6 +495,36 @@ body {
 """
 
 
+def _pdf_strategy_rows(ctx):
+    ai = ctx.get("ai_section_5_strategies") or []
+    if ai:
+        rows = [(s["material"], s["saving"]) for s in ai]
+    else:
+        rows = [
+            ("Ready-mix concrete &amp; cement",
+             "&#8722;40 kgCO<sub>2</sub>eq/m&#178; &nbsp;(30% of total) &nbsp;25% GGBS/Fly Ash blend &#8594; 139 &#8594; 104 kgCO<sub>2</sub>eq/m&#178;"),
+            ("Steel",
+             "&#8722;20 kgCO<sub>2</sub>eq/m&#178; &nbsp;(15% of total) &nbsp;20% recycled content &#8594; 69 &#8594; 55 kgCO<sub>2</sub>eq/m&#178;"),
+            ("Reinforcement bar (rebar)",
+             "&#8722;35 kgCO<sub>2</sub>eq/m&#178; &nbsp;(15% of total) &nbsp;Low-carbon rebar specification"),
+            ("Total potential embodied saving",
+             "&#8722;85 kgCO<sub>2</sub>eq/m&#178; &nbsp;(12.5% reduction from baseline)"),
+        ]
+
+    html_rows = []
+    for i, (material, saving) in enumerate(rows):
+        is_total = material.lower().startswith("total")
+        odd_class = ' class="odd"' if i % 2 == 0 else ''
+        bold_style = ' style="font-weight:bold;"' if is_total else ''
+        html_rows.append(
+            f'  <tr{odd_class}>\n'
+            f'    <td class="label-col"{bold_style}>{material}</td>\n'
+            f'    <td{bold_style}>{saving}</td>\n'
+            f'  </tr>'
+        )
+    return "\n".join(html_rows)
+
+
 def _pdf_html(ctx):
     b = ctx["building"]
     loc = ctx["location"]
@@ -537,7 +679,7 @@ def _pdf_html(ctx):
 {ctx["donut_card"]}
 <p class="fig-caption">Figure 1 &#8212; Whole life carbon cycle of the building</p>
 
-<p class="body-text">Operational carbon accounts for <span class="highlight">{ctx["op_pct"]}%</span> of the total carbon footprint (<span class="highlight">{ctx["operational_carbon"]} kgCO<sub>2</sub>eq/m&#178;</span>), reflecting the dominant role of building energy systems over a <span class="highlight">{b.reference_period}-year</span> assessment period. Embodied carbon contributes the remaining <span class="highlight">{ctx["em_pct"]}%</span> (<span class="highlight">{ctx["embodied_carbon"]} kgCO<sub>2</sub>eq/m&#178;</span>) which underscores the importance of reducing embodied carbon, which carries significant weight in overall emissions&#8212;particularly those generated during the construction and renovation phases of a building. It is important to note that, unlike operational carbon, embodied carbon is released upfront, resulting in substantial emissions at the time a building is constructed or renovated.</p>
+<p class="body-text">{ctx["ai_section_2_narrative"] or f'Operational carbon accounts for <span class="highlight">{ctx["op_pct"]}%</span> of the total carbon footprint (<span class="highlight">{ctx["operational_carbon"]} kgCO<sub>2</sub>eq/m&#178;</span>), reflecting the dominant role of building energy systems over a <span class="highlight">{b.reference_period}-year</span> assessment period. Embodied carbon contributes the remaining <span class="highlight">{ctx["em_pct"]}%</span> (<span class="highlight">{ctx["embodied_carbon"]} kgCO<sub>2</sub>eq/m&#178;</span>) which underscores the importance of reducing embodied carbon, which carries significant weight in overall emissions&#8212;particularly those generated during the construction and renovation phases of a building. It is important to note that, unlike operational carbon, embodied carbon is released upfront, resulting in substantial emissions at the time a building is constructed or renovated.'}</p>
 
 <!-- ===== PAGE 4: SECTION 3 ===== -->
 <div class="page-break"></div>
@@ -560,7 +702,7 @@ def _pdf_html(ctx):
 {_chart_img(ctx["card_material"], "88%")}
 <p class="fig-caption">Figure 3 &#8212; Embodied carbon by material (Materials tab)</p>
 
-<p class="body-text">Rebar and ready-mix concrete together account for over <span class="highlight">81%</span> of total embodied carbon &#8212; a pattern typical of reinforced concrete-frame office buildings. Strategies to reduce this share include specifying low-carbon concrete mixes (<span class="highlight">GGBS</span> or fly ash blends), using <span class="highlight">recycled-content</span> reinforcement, and minimising structural over-design.</p>
+<p class="body-text">{ctx["ai_section_3_material_insight"] or "Rebar and ready-mix concrete together account for over <span class=\"highlight\">81%</span> of total embodied carbon &#8212; a pattern typical of reinforced concrete-frame office buildings. Strategies to reduce this share include specifying low-carbon concrete mixes (<span class=\"highlight\">GGBS</span> or fly ash blends), using <span class=\"highlight\">recycled-content</span> reinforcement, and minimising structural over-design."}</p>
 
 <!-- ===== PAGE 5: SECTION 4 — OPERATIONAL CARBON ===== -->
 <div class="page-break"></div>
@@ -577,7 +719,7 @@ def _pdf_html(ctx):
 
 <p class="fig-caption" style="margin-top:80pt;">Figure 4 &#8212; Operational carbon by system and appliance (Energy tab)</p>
 
-<p class="body-text"><span class="highlight">Cooling</span> is the dominant operational carbon contributor at <span class="highlight">43%</span>, driven primarily by split AC units (<span class="highlight">28%</span> of building total) and VRF systems (<span class="highlight">13%</span>).</p>
+<p class="body-text">{ctx["ai_section_4_operational_insight"] or '<span class="highlight">Cooling</span> is the dominant operational carbon contributor at <span class="highlight">43%</span>, driven primarily by split AC units (<span class="highlight">28%</span> of building total) and VRF systems (<span class="highlight">13%</span>).'}</p>
 
 <!-- ===== PAGE 6: SECTION 5 — BENCHMARKING ===== -->
 <div class="page-break"></div>
@@ -615,7 +757,7 @@ def _pdf_html(ctx):
   </tr>
 </table>
 
-<div class="callout">This building performs better than 78% of peer projects in Germany (452 residential projects, Baden-W&#252;rttemberg, 2024&#8211;2025). It is rated in the Top 25% tier. Benchmark data is region- and building-type specific.</div>
+<div class="callout">{ctx["ai_section_5_benchmark_callout"] or "This building performs better than 78% of peer projects in Germany (452 residential projects, Baden-W&#252;rttemberg, 2024&#8211;2025). It is rated in the Top 25% tier. Benchmark data is region- and building-type specific."}</div>
 
 <p class="subsection-heading">5.3 &nbsp; Optimisation Strategies</p>
 
@@ -626,22 +768,7 @@ def _pdf_html(ctx):
     <td class="label-col" style="font-weight:bold; color:#374151;">Strategy</td>
     <td style="font-weight:bold; color:#374151;">Potential saving / Notes</td>
   </tr>
-  <tr>
-    <td class="label-col">Ready-mix concrete &amp; cement</td>
-    <td>&#8722;40 kgCO<sub>2</sub>eq/m&#178; &nbsp;(30% of total) &nbsp;25% GGBS/Fly Ash blend &#8594; 139 &#8594; 104 kgCO<sub>2</sub>eq/m&#178;</td>
-  </tr>
-  <tr class="odd">
-    <td class="label-col">Steel</td>
-    <td>&#8722;20 kgCO<sub>2</sub>eq/m&#178; &nbsp;(15% of total) &nbsp;20% recycled content &#8594; 69 &#8594; 55 kgCO<sub>2</sub>eq/m&#178;</td>
-  </tr>
-  <tr>
-    <td class="label-col">Reinforcement bar (rebar)</td>
-    <td>&#8722;35 kgCO<sub>2</sub>eq/m&#178; &nbsp;(15% of total) &nbsp;Low-carbon rebar specification</td>
-  </tr>
-  <tr class="odd">
-    <td class="label-col" style="font-weight:bold;">Total potential embodied saving</td>
-    <td style="font-weight:bold;">&#8722;85 kgCO<sub>2</sub>eq/m&#178; &nbsp;(12.5% reduction from baseline)</td>
-  </tr>
+  {_pdf_strategy_rows(ctx)}
 </table>
 
 <p class="body-text">Operational carbon savings are not yet modelled for this project. Recommended next steps include specifying higher-efficiency cooling equipment, exploring on-site renewable generation, and re-assessing the grid emission factor annually as the national grid decarbonises.</p>
@@ -1025,23 +1152,27 @@ def _build_docx(ctx):
     # Narrative
     narrative = doc.add_paragraph()
     narrative.paragraph_format.space_before = Pt(8)
-    for text, highlight in [
-        (f"Operational carbon accounts for ", False),
-        (f"{ctx['op_pct']}%", True),
-        (f" of the total carbon footprint (", False),
-        (f"{ctx['operational_carbon']} kgCO₂eq/m²", True),
-        (f"), reflecting the dominant role of building energy systems over a ", False),
-        (f"{bldg.reference_period}-year", True),
-        (f" assessment period. Embodied carbon contributes the remaining ", False),
-        (f"{ctx['em_pct']}%", True),
-        (f" (", False),
-        (f"{ctx['embodied_carbon']} kgCO₂eq/m²", True),
-        (f") which underscores the importance of reducing embodied carbon, which carries significant weight in overall emissions—particularly those generated during the construction and renovation phases of a building. It is important to note that, unlike operational carbon, embodied carbon is released upfront, resulting in substantial emissions at the time a building is constructed or renovated.", False),
-    ]:
-        r = narrative.add_run(text)
+    if ctx.get("ai_section_2_narrative"):
+        r = narrative.add_run(ctx["ai_section_2_narrative"])
         r.font.size = Pt(10)
-        if highlight:
-            r.font.highlight_color = 7  # yellow
+    else:
+        for text, highlight in [
+            (f"Operational carbon accounts for ", False),
+            (f"{ctx['op_pct']}%", True),
+            (f" of the total carbon footprint (", False),
+            (f"{ctx['operational_carbon']} kgCO₂eq/m²", True),
+            (f"), reflecting the dominant role of building energy systems over a ", False),
+            (f"{bldg.reference_period}-year", True),
+            (f" assessment period. Embodied carbon contributes the remaining ", False),
+            (f"{ctx['em_pct']}%", True),
+            (f" (", False),
+            (f"{ctx['embodied_carbon']} kgCO₂eq/m²", True),
+            (f") which underscores the importance of reducing embodied carbon, which carries significant weight in overall emissions—particularly those generated during the construction and renovation phases of a building. It is important to note that, unlike operational carbon, embodied carbon is released upfront, resulting in substantial emissions at the time a building is constructed or renovated.", False),
+        ]:
+            r = narrative.add_run(text)
+            r.font.size = Pt(10)
+            if highlight:
+                r.font.highlight_color = 7  # yellow
 
     # ── Section 3: Embodied Carbon ────────────────────────────────────────────
     doc.add_page_break()
@@ -1093,18 +1224,21 @@ def _build_docx(ctx):
     p3close = doc.add_paragraph()
     p3close.paragraph_format.space_before = Pt(10)
     p3close.paragraph_format.space_after = Pt(12)
-    for text, highlight in [
-        ("Rebar and ready-mix concrete together account for over ", False),
-        ("81%", True),
-        (" of total embodied carbon — a pattern typical of reinforced concrete-frame office buildings. "
-         "Strategies to reduce this share include specifying low-carbon concrete mixes (", False),
-        ("GGBS", True),
-        (" or fly ash blends), using ", False),
-        ("recycled-content", True),
-        (" reinforcement, and minimising structural over-design.", False),
-    ]:
-        r = p3close.add_run(text); r.font.size = Pt(10)
-        if highlight: r.font.highlight_color = 7
+    if ctx.get("ai_section_3_material_insight"):
+        r = p3close.add_run(ctx["ai_section_3_material_insight"]); r.font.size = Pt(10)
+    else:
+        for text, highlight in [
+            ("Rebar and ready-mix concrete together account for over ", False),
+            ("81%", True),
+            (" of total embodied carbon — a pattern typical of reinforced concrete-frame office buildings. "
+             "Strategies to reduce this share include specifying low-carbon concrete mixes (", False),
+            ("GGBS", True),
+            (" or fly ash blends), using ", False),
+            ("recycled-content", True),
+            (" reinforcement, and minimising structural over-design.", False),
+        ]:
+            r = p3close.add_run(text); r.font.size = Pt(10)
+            if highlight: r.font.highlight_color = 7
 
     # ── Section 4: Operational Carbon ────────────────────────────────────────
     doc.add_page_break()
@@ -1137,18 +1271,21 @@ def _build_docx(ctx):
 
     p41 = doc.add_paragraph()
     p41.paragraph_format.space_before = Pt(10)
-    for text, highlight in [
-        ("Cooling", True),
-        (" is the dominant operational carbon contributor at ", False),
-        ("43%", True),
-        (", driven primarily by split AC units (", False),
-        ("28%", True),
-        (" of building total) and VRF systems (", False),
-        ("13%", True),
-        (").", False),
-    ]:
-        r = p41.add_run(text); r.font.size = Pt(10)
-        if highlight: r.font.highlight_color = 7
+    if ctx.get("ai_section_4_operational_insight"):
+        r = p41.add_run(ctx["ai_section_4_operational_insight"]); r.font.size = Pt(10)
+    else:
+        for text, highlight in [
+            ("Cooling", True),
+            (" is the dominant operational carbon contributor at ", False),
+            ("43%", True),
+            (", driven primarily by split AC units (", False),
+            ("28%", True),
+            (" of building total) and VRF systems (", False),
+            ("13%", True),
+            (").", False),
+        ]:
+            r = p41.add_run(text); r.font.size = Pt(10)
+            if highlight: r.font.highlight_color = 7
 
     # ── Section 5: Benchmarking & Carbon Savings ──────────────────────────────
     doc.add_page_break()
@@ -1199,6 +1336,7 @@ def _build_docx(ctx):
     pPr5 = callout5._p.get_or_add_pPr()
     shd5 = OxmlElement("w:shd"); shd5.set(qn("w:val"), "clear"); shd5.set(qn("w:color"), "auto"); shd5.set(qn("w:fill"), "EFF6FF"); pPr5.append(shd5)
     cr5 = callout5.add_run(
+        ctx.get("ai_section_5_benchmark_callout") or
         "This building performs better than 78% of peer projects in Germany (452 residential projects, "
         "Baden-Württemberg, 2024–2025). It is rated in the Top 25% tier. Benchmark data is "
         "region- and building-type specific."
@@ -1212,17 +1350,21 @@ def _build_docx(ctx):
         "carbon, ordered by percentage of total footprint:"
     ).paragraph_format.space_after = Pt(8)
 
-    opt_rows = [
-        ("Strategy", "Potential saving / Notes", True),
-        ("Ready-mix concrete & cement",
-         "−40 kgCO₂eq/m²  (30% of total)  25% GGBS/Fly Ash blend → 139 → 104 kgCO₂eq/m²", False),
-        ("Steel",
-         "−20 kgCO₂eq/m²  (15% of total)  20% recycled content → 69 → 55 kgCO₂eq/m²", False),
-        ("Reinforcement bar (rebar)",
-         "−35 kgCO₂eq/m²  (15% of total)  Low-carbon rebar specification", False),
-        ("Total potential embodied saving",
-         "−85 kgCO₂eq/m²  (12.5% reduction from baseline)", True),
-    ]
+    ai_strategies = ctx.get("ai_section_5_strategies") or []
+    if ai_strategies:
+        strategy_data = [(s["material"], s["saving"], s["material"].lower().startswith("total")) for s in ai_strategies]
+    else:
+        strategy_data = [
+            ("Ready-mix concrete & cement",
+             "−40 kgCO₂eq/m²  (30% of total)  25% GGBS/Fly Ash blend → 139 → 104 kgCO₂eq/m²", False),
+            ("Steel",
+             "−20 kgCO₂eq/m²  (15% of total)  20% recycled content → 69 → 55 kgCO₂eq/m²", False),
+            ("Reinforcement bar (rebar)",
+             "−35 kgCO₂eq/m²  (15% of total)  Low-carbon rebar specification", False),
+            ("Total potential embodied saving",
+             "−85 kgCO₂eq/m²  (12.5% reduction from baseline)", True),
+        ]
+    opt_rows = [("Strategy", "Potential saving / Notes", True)] + strategy_data
     opt_table = doc.add_table(rows=len(opt_rows), cols=2)
     opt_table.style = "Table Grid"
     fill_opt = ["F3F4F6", "FFFFFF", "F3F4F6", "FFFFFF", "F3F4F6"]
@@ -1265,6 +1407,8 @@ def export_building(request, building_id):
     )
     filename_base = building.name.replace(" ", "_")
 
+    token = request.POST.get("export_token", "")
+
     if fmt == "word":
         doc = _build_docx(ctx)
         buffer = io.BytesIO()
@@ -1275,6 +1419,8 @@ def export_building(request, building_id):
             content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
         response["Content-Disposition"] = f'attachment; filename="BEAT_Report_{filename_base}.docx"'
+        if token:
+            response.set_cookie("export_done", token, max_age=60, samesite="Lax")
         return response
 
     from xhtml2pdf import pisa
@@ -1284,4 +1430,6 @@ def export_building(request, building_id):
     buffer.seek(0)
     response = HttpResponse(buffer.getvalue(), content_type="application/pdf")
     response["Content-Disposition"] = f'attachment; filename="BEAT_Report_{filename_base}.pdf"'
+    if token:
+        response.set_cookie("export_done", token, max_age=60, samesite="Lax")
     return response

--- a/pages/views/building/building_report.py
+++ b/pages/views/building/building_report.py
@@ -7,7 +7,7 @@ from datetime import date
 
 from openai import OpenAI
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.conf import settings
 from django.views.decorators.http import require_http_methods
@@ -217,7 +217,9 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
     material_data = get_embodied_carbon_by_material(building)
     operational_data = get_operational_carbon_by_system(building)
 
-    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data) or {}
+    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data)
+    if ai is None:
+        raise RuntimeError("AI narrative generation failed")
 
     def fmt(val):
         return f"{val:,.1f}"
@@ -245,11 +247,11 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
         "card_material": card_material,
         "card_savings": card_savings,
         # AI-generated narratives (fall back to None if generation failed)
-        "ai_section_2_narrative": ai.get("section_2_narrative"),
-        "ai_section_3_material_insight": ai.get("section_3_material_insight"),
-        "ai_section_4_operational_insight": ai.get("section_4_operational_insight"),
-        "ai_section_5_benchmark_callout": ai.get("section_5_benchmark_callout"),
-        "ai_section_5_strategies": ai.get("section_5_strategies"),
+        "ai_section_2_narrative": ai["section_2_narrative"],
+        "ai_section_3_material_insight": ai["section_3_material_insight"],
+        "ai_section_4_operational_insight": ai["section_4_operational_insight"],
+        "ai_section_5_benchmark_callout": ai["section_5_benchmark_callout"],
+        "ai_section_5_strategies": ai["section_5_strategies"],
     }
 
 
@@ -1398,16 +1400,19 @@ def _build_docx(ctx):
 def export_building(request, building_id):
     building = get_object_or_404(Building, pk=building_id, created_by=request.user)
     fmt = request.POST.get("format", "pdf")
-    ctx = _build_context(
-        building, request,
-        card_donut=request.POST.get("card_donut", ""),
-        card_assembly=request.POST.get("card_assembly", ""),
-        card_material=request.POST.get("card_material", ""),
-        card_savings=request.POST.get("card_savings", ""),
-    )
-    filename_base = building.name.replace(" ", "_")
+    try:
+        ctx = _build_context(
+            building, request,
+            card_donut=request.POST.get("card_donut", ""),
+            card_assembly=request.POST.get("card_assembly", ""),
+            card_material=request.POST.get("card_material", ""),
+            card_savings=request.POST.get("card_savings", ""),
+        )
+    except Exception as exc:
+        logger.warning("Report generation failed for building %s: %s", building_id, exc)
+        return JsonResponse({"error": "Something went wrong — we couldn't generate the report at the moment. Please try again later."}, status=500)
 
-    token = request.POST.get("export_token", "")
+    filename_base = building.name.replace(" ", "_")
 
     if fmt == "word":
         doc = _build_docx(ctx)
@@ -1419,8 +1424,6 @@ def export_building(request, building_id):
             content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
         response["Content-Disposition"] = f'attachment; filename="BEAT_Report_{filename_base}.docx"'
-        if token:
-            response.set_cookie("export_done", token, max_age=60, samesite="Lax")
         return response
 
     from xhtml2pdf import pisa
@@ -1430,6 +1433,4 @@ def export_building(request, building_id):
     buffer.seek(0)
     response = HttpResponse(buffer.getvalue(), content_type="application/pdf")
     response["Content-Disposition"] = f'attachment; filename="BEAT_Report_{filename_base}.pdf"'
-    if token:
-        response.set_cookie("export_done", token, max_age=60, samesite="Lax")
     return response

--- a/pages/views/building/components.py
+++ b/pages/views/building/components.py
@@ -24,11 +24,12 @@ def building_components(request):
     return render(request, "pages/add-building/components/"+template, context)
 
 def new_building(request):
+    building_uuid = request.GET.get('building_uuid')
     context = {
                 "building_id": None,
                 "building": None,
                 "structural_components": [],
-                "edit_mode": False,
+                "edit_mode": bool(building_uuid),
             }
     form = BuildingGeneralInformation()
     detailedForm = BuildingDetailedInformation()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 annotated-types==0.7.0
+openai==2.37.0
 asgiref==3.8.1
 djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1

--- a/templates/pages/add-building/add-building.html
+++ b/templates/pages/add-building/add-building.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static  %}
 
-{% block title %}{% translate "Add Building" %}{% endblock title %}
+{% block title %}{% if edit_mode %}{% translate "Edit Building" %}{% else %}{% translate "Add Building" %}{% endif %}{% endblock title %}
 
 
 {% block new-building %}

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -88,7 +88,6 @@
           <input type="hidden" name="card_assembly" id="export-card-assembly-img"/>
           <input type="hidden" name="card_material" id="export-card-material-img"/>
           <input type="hidden" name="card_savings" id="export-card-savings-img"/>
-          <input type="hidden" name="export_token" id="export-token"/>
         </form>
         <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
         <script>
@@ -106,14 +105,15 @@
             overlay.style.cssText = 'display:none;position:fixed;inset:0;background:rgba(15,39,68,0.55);z-index:9999;flex-direction:column;align-items:center;justify-content:center;gap:16px;';
             overlay.innerHTML = `
               <div style="background:#ffffff;border-radius:16px;padding:32px 40px;display:flex;flex-direction:column;align-items:center;gap:16px;min-width:380px;box-shadow:0 8px 32px rgba(0,0,0,0.18);">
-                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg id="export-overlay-icon" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#16a34a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
                 </svg>
                 <p id="export-overlay-label" style="font-family:sans-serif;font-size:15px;font-weight:600;color:#0f2744;margin:0;">Preparing export…</p>
-                <div style="width:100%;background:#e5e7eb;border-radius:9999px;height:8px;overflow:hidden;">
+                <div id="export-progress-wrap" style="width:100%;background:#e5e7eb;border-radius:9999px;height:8px;overflow:hidden;">
                   <div id="export-progress-bar" style="height:100%;width:0%;background:#16a34a;border-radius:9999px;transition:width 0.3s ease;"></div>
                 </div>
                 <p id="export-overlay-step" style="font-family:sans-serif;font-size:12px;color:#6b7280;margin:0;">Starting…</p>
+                <button id="export-overlay-close" onclick="hideExportOverlay()" style="display:none;margin-top:4px;padding:8px 20px;background:#0f2744;color:#fff;border:none;border-radius:8px;font-size:13px;cursor:pointer;">Close</button>
               </div>`;
             document.body.appendChild(overlay);
           })();
@@ -132,7 +132,22 @@
           }
 
           function hideExportOverlay() {
-            document.getElementById('export-overlay').style.display = 'none';
+            const overlay = document.getElementById('export-overlay');
+            overlay.style.display = 'none';
+            // Reset error state for next time
+            document.getElementById('export-overlay-icon').setAttribute('stroke', '#16a34a');
+            document.getElementById('export-overlay-icon').innerHTML = '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>';
+            document.getElementById('export-progress-wrap').style.display = '';
+            document.getElementById('export-overlay-close').style.display = 'none';
+          }
+
+          function showExportError(message) {
+            document.getElementById('export-overlay-icon').setAttribute('stroke', '#dc2626');
+            document.getElementById('export-overlay-icon').innerHTML = '<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>';
+            document.getElementById('export-overlay-label').textContent = 'Export failed';
+            document.getElementById('export-progress-wrap').style.display = 'none';
+            document.getElementById('export-overlay-step').textContent = message;
+            document.getElementById('export-overlay-close').style.display = '';
           }
 
           function triggerExport(fmt) {
@@ -164,25 +179,37 @@
               setExportProgress(90, 'Generating document…');
               setTimeout(function() {
                 setExportProgress(100, 'Generating AI insights…');
-                // Generate a unique token so we know which download to wait for
-                var token = Date.now().toString();
-                document.getElementById('export-token').value = token;
-                // Delete any old export_done cookie first
-                document.cookie = 'export_done=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
-                document.getElementById('export-form').submit();
-                // Poll for the export_done cookie the server sets when file is ready
-                var poller = setInterval(function() {
-                  var match = document.cookie.match(/export_done=([^;]+)/);
-                  if (match && match[1] === token) {
-                    clearInterval(poller);
-                    document.cookie = 'export_done=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
-                    hideExportOverlay();
-                  }
-                }, 500);
+                var form = document.getElementById('export-form');
+                var formData = new FormData(form);
+                fetch(form.action, { method: 'POST', body: formData })
+                  .then(function(response) {
+                    var contentType = response.headers.get('content-type') || '';
+                    if (!response.ok || contentType.includes('application/json')) {
+                      return response.json().then(function(data) {
+                        showExportError(data.error || 'Something went wrong. Please try again later.');
+                      });
+                    }
+                    return response.blob().then(function(blob) {
+                      var disposition = response.headers.get('content-disposition') || '';
+                      var match = disposition.match(/filename="([^"]+)"/);
+                      var filename = match ? match[1] : 'BEAT_Report.pdf';
+                      var url = URL.createObjectURL(blob);
+                      var a = document.createElement('a');
+                      a.href = url;
+                      a.download = filename;
+                      document.body.appendChild(a);
+                      a.click();
+                      a.remove();
+                      URL.revokeObjectURL(url);
+                      hideExportOverlay();
+                    });
+                  })
+                  .catch(function() {
+                    showExportError('Something went wrong. Please try again later.');
+                  });
               }, 300);
             }).catch(function(err) {
-              hideExportOverlay();
-              alert('Export failed: ' + err.message);
+              showExportError('Something went wrong. Please try again later.');
             });
           }
         </script>

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -88,6 +88,7 @@
           <input type="hidden" name="card_assembly" id="export-card-assembly-img"/>
           <input type="hidden" name="card_material" id="export-card-material-img"/>
           <input type="hidden" name="card_savings" id="export-card-savings-img"/>
+          <input type="hidden" name="export_token" id="export-token"/>
         </form>
         <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
         <script>
@@ -160,11 +161,24 @@
               return captureCard('export-card-savings');
             }).then(function(savings) {
               document.getElementById('export-card-savings-img').value = savings;
-              setExportProgress(100, 'Generating document…');
+              setExportProgress(90, 'Generating document…');
               setTimeout(function() {
+                setExportProgress(100, 'Generating AI insights…');
+                // Generate a unique token so we know which download to wait for
+                var token = Date.now().toString();
+                document.getElementById('export-token').value = token;
+                // Delete any old export_done cookie first
+                document.cookie = 'export_done=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
                 document.getElementById('export-form').submit();
-                // Close overlay after browser has received the file download
-                setTimeout(hideExportOverlay, 2500);
+                // Poll for the export_done cookie the server sets when file is ready
+                var poller = setInterval(function() {
+                  var match = document.cookie.match(/export_done=([^;]+)/);
+                  if (match && match[1] === token) {
+                    clearInterval(poller);
+                    document.cookie = 'export_done=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+                    hideExportOverlay();
+                  }
+                }, 500);
               }, 300);
             }).catch(function(err) {
               hideExportOverlay();


### PR DESCRIPTION
## Summary

  - **AI-generated report narratives**: Integrates GPT-4o-mini via `REPORT_API_KEY` env var. A single API call returns a
   JSON object with 5 narrative keys (`section_2_narrative`, `section_3_material_insight`,
  `section_4_operational_insight`, `section_5_benchmark_callout`, `section_5_strategies`). Both PDF and DOCX exports use
   these values with fallback to the original hardcoded text if the API call fails or the key is absent.
  - **Reliable export modal close**: Replaces `window.blur` (unreliable for file downloads) with server-set cookie
  polling. The server sets an `export_done=<token>` cookie on the response; the frontend polls every 500ms and closes
  the progress overlay when the token matches.
  - **Edit Building page title**: The add/edit building page was always showing "Add Building" in the browser tab.
  `components.py` now sets `edit_mode=True` when `building_uuid` is in the request, and the template conditionally
  renders "Edit Building" or "Add Building".
  - Adds `openai==2.37.0` to `requirements.txt`.

  ## Test plan

  - [x] Export a building report (PDF and DOCX) — progress modal should close automatically when the file download
  starts
  - [x] If `REPORT_API_KEY` is set and has credits, confirm AI-generated paragraphs appear in report sections 2–5
  - [x] If `REPORT_API_KEY` is missing or invalid, we show error
  - [x] Open edit building (`/building/edit?building_uuid=...`) — browser tab title should read "Edit Building"
  - [x] Open add building (`/building/_new`) — browser tab title should still read "Add Building"