### PR TITLE
Task/qa feedback

### DIFF
--- a/pages/views/building/building_step_structural.py
+++ b/pages/views/building/building_step_structural.py
@@ -471,6 +471,16 @@ def handle_save_assembly(request):
         if not materials:
             return JsonResponse({"success": False, "error": "At least one material is required"}, status=400)
 
+        # For pcs dimension, sum of material quantities must equal component quantity
+        if mode == "component" and assembly_data.get("dimension") == "pcs":
+            component_qty = float(assembly_data.get("quantity") or 0)
+            qty_sum = sum(float(m.get("quantity") or 0) for m in materials)
+            if round(qty_sum, 3) != round(component_qty, 3):
+                return JsonResponse({
+                    "success": False,
+                    "error": f"The sum of EPD quantities ({round(qty_sum, 3)} pcs) must equal the component quantity ({round(component_qty, 3)} pcs)."
+                }, status=400)
+
         # Create or update Assembly
         if assembly_id:
             # Update existing assembly
@@ -722,9 +732,13 @@ def handle_search_templates(request):
             structuralproduct__classification__technique_id=technique_id
         ).distinct()
 
-    # Apply mode filter (System Component vs My Component)
-    if mode:
-        assemblies = assemblies.filter(mode=mode)
+    # Apply mode filter (System Component = generic mode OR staff/superuser created, My Component = own)
+    if mode == "system":
+        assemblies = assemblies.filter(
+            Q(mode="generic") | Q(created_by__is_staff=True) | Q(created_by__is_superuser=True)
+        )
+    elif mode == "custom":
+        assemblies = assemblies.filter(created_by=request.user)
 
     # Optimize queries with prefetch_related and select_related
     assemblies = assemblies.select_related("country", "city", "created_by").prefetch_related(

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ setuptools==80.9.0
 six==1.17.0
 sqlparse==0.4.3
 tenacity==9.1.2
-typing_extensions==4.9.0
+typing_extensions==4.15.0
 tzdata==2025.2
 Unidecode==1.4.0
 urllib3==1.26.14


### PR DESCRIPTION
## Summary

- **System Component filter fix**: The "System Component" filter in the template selection modal was broken — it was
  sending `mode=system` but the model stores `mode=generic`, so it matched nothing. Fixed the backend filter to correctly identify system components as those with `mode=generic` OR created by a staff/superuser user. "My Component" correctly filters to the current user's own assemblies.
- **typing-extensions version bump**: Updated `typing_extensions` from `4.9.0` to `4.15.0` in `requirements.txt` to
  match the locally installed version.

  ## Test plan

  - [x] Open the template selection modal (Add Component → Select from default → Advanced Search)
  - [x] Select "System Component" from the All Types dropdown — should return assemblies created by staff/superuser or
  with `mode=generic`
  - [x] Select "My Component" — should return only assemblies created by the current user
  - [x] Select "All Types" — should return both