### PR TITLE
fix: show full building name in listing, show all EPDs in structural search regardless of dimension unit

### DIFF
--- a/pages/views/assembly/epd_filtering.py
+++ b/pages/views/assembly/epd_filtering.py
@@ -77,7 +77,9 @@ def get_filtered_epd_list(request, dimension=None, operational=False):
         req = request.POST if request.method == "POST" else request.GET
         # Add filters conditionally
         dimension = req.get("dimension")
-        if dimension and dimension != "None":
+        # Only filter by dimension for operational EPDs — for structural, all EPDs
+        # are shown regardless of unit; compatibility is checked per-EPD on Add.
+        if operational and dimension and dimension != "None":
             filtered_epds = filter_by_dimension(filtered_epds, dimension)
 
         if childcategory := req.get("childcategory"):

--- a/templates/pages/home/partials/buildings_list.html
+++ b/templates/pages/home/partials/buildings_list.html
@@ -20,7 +20,7 @@
                 ></span>
               </div>
               <div class="flex flex-col w-full gap-1.5">
-                <h6 class="text-base/6 font-bold">{{ building.name | truncatechars:20 }}</h6>
+                <h6 class="text-base/6 font-bold">{{ building.name }}</h6>
                 <ul class="flex gap-2">
                   <li
                     class="flex items-center gap-1 border p-1 pr-2 rounded-md border-[var(--stroke--soft-200)]"


### PR DESCRIPTION
## Summary
- Fix building name truncation
- Fix structural epd search to remove dimension constraint