### PR TITLE
Wire operational carbon by building system into the Systems tab

### DIFF
--- a/pages/tests/test_operational_carbon_by_system.py
+++ b/pages/tests/test_operational_carbon_by_system.py
@@ -1,0 +1,209 @@
+"""Tests for operational carbon by building system (Systems tab).
+
+Covers:
+- ``_derive_grid_emission_factor``: grid factor = electricity EPD B6 GWP / declared_amount
+- ``get_operational_carbon_by_system``: per-system intensity (kWh * grid_factor / floor_area)
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from pages.tests.test_impact_calculation import create_epd  # noqa: F401 (fixture)
+
+from pages.models.epd import EPDImpact, Impact, ImpactCategoryKey, LifeCycleStage, Unit
+from pages.models.building import OperationalProduct, Building
+from pages.models.building_operation.energy_summary import EnergySummary
+from pages.models.climate_type import ClimateType
+
+from pages.views.building.building_stats import (
+    _derive_grid_emission_factor,
+    get_operational_carbon_by_system,
+)
+
+
+@pytest.fixture
+def create_impact_B6():
+    def _create_impact_B6(impact):
+        return Impact.objects.create(
+            impact_category=impact,
+            life_cycle_stage=LifeCycleStage.B6,
+        )
+
+    return _create_impact_B6
+
+
+@pytest.fixture
+def create_epd_impact():
+    def _create_epd_impact(epd, value, impact):
+        return EPDImpact.objects.create(epd=epd, impact=impact, value=value)
+
+    return _create_epd_impact
+
+
+@pytest.fixture
+def create_building():
+    def _create_building(total_floor_area=Decimal("100")):
+        climate, _ = ClimateType.objects.get_or_create(name="cold")
+        return Building.objects.create(
+            name="Test Building",
+            climate_zone=climate,
+            total_floor_area=total_floor_area,
+        )
+
+    return _create_building
+
+
+@pytest.fixture
+def create_operationalproduct():
+    def _create_operationalproduct(building, epd, quantity, unit):
+        return OperationalProduct.objects.create(
+            building=building,
+            epd=epd,
+            quantity=quantity,
+            input_unit=unit,
+        )
+
+    return _create_operationalproduct
+
+
+@pytest.fixture
+def create_energy_summary():
+    def _create_energy_summary(building, **kwh):
+        return EnergySummary.objects.create(building=building, **kwh)
+
+    return _create_energy_summary
+
+
+@pytest.fixture
+def create_electricity_epd(create_epd, create_impact_B6, create_epd_impact):
+    """Create a kWh-declared electricity EPD with a B6 GWP value."""
+
+    def _create_electricity_epd(gwp_value, declared_amount=Decimal("1")):
+        epd = create_epd("electricity grid mix", Unit.KWH, [])
+        epd.declared_amount = declared_amount
+        epd.save()
+        impact_gwp = create_impact_B6(ImpactCategoryKey.GWP)
+        create_epd_impact(epd, gwp_value, impact_gwp)
+        return epd
+
+    return _create_electricity_epd
+
+
+# ---------------------------------------------------------------------------
+# _derive_grid_emission_factor
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_grid_factor_basic(
+    create_building, create_electricity_epd, create_operationalproduct
+):
+    building = create_building()
+    epd = create_electricity_epd(Decimal("0.5"), declared_amount=Decimal("1"))
+    create_operationalproduct(building, epd, Decimal("100"), Unit.KWH)
+
+    assert _derive_grid_emission_factor(building) == Decimal("0.5")
+
+
+@pytest.mark.django_db
+def test_grid_factor_with_declared_amount(
+    create_building, create_electricity_epd, create_operationalproduct
+):
+    building = create_building()
+    epd = create_electricity_epd(Decimal("0.5"), declared_amount=Decimal("2"))
+    create_operationalproduct(building, epd, Decimal("100"), Unit.KWH)
+
+    assert _derive_grid_emission_factor(building) == Decimal("0.25")
+
+
+@pytest.mark.django_db
+def test_grid_factor_no_electricity_epd(create_building):
+    building = create_building()
+    assert _derive_grid_emission_factor(building) == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# get_operational_carbon_by_system
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_system_carbon_basic(
+    create_building,
+    create_electricity_epd,
+    create_operationalproduct,
+    create_energy_summary,
+):
+    building = create_building(total_floor_area=Decimal("100"))
+    epd = create_electricity_epd(Decimal("0.5"))
+    create_operationalproduct(building, epd, Decimal("1"), Unit.KWH)
+    create_energy_summary(
+        building, cooling_kwh=Decimal("1000"), lighting_kwh=Decimal("500")
+    )
+
+    result = get_operational_carbon_by_system(building)
+
+    # cooling = 1000 * 0.5 / 100 = 5.0 ; lighting = 500 * 0.5 / 100 = 2.5
+    assert result["labels"] == ["Cooling systems", "Lighting systems"]
+    assert result["absolute"] == [5.0, 2.5]
+    assert result["total"] == 7.5
+    assert result["data"][0] == pytest.approx(66.7, abs=0.1)
+    assert result["data"][1] == pytest.approx(33.3, abs=0.1)
+    assert "warning" not in result
+
+
+@pytest.mark.django_db
+def test_system_carbon_floor_area_zero_blocks(
+    create_building, create_electricity_epd, create_operationalproduct, create_energy_summary
+):
+    building = create_building(total_floor_area=Decimal("0"))
+    epd = create_electricity_epd(Decimal("0.5"))
+    create_operationalproduct(building, epd, Decimal("1"), Unit.KWH)
+    create_energy_summary(building, cooling_kwh=Decimal("1000"))
+
+    result = get_operational_carbon_by_system(building)
+
+    assert result["labels"] == []
+    assert result["total"] == 0
+    assert result.get("blocked") is True
+
+
+@pytest.mark.django_db
+def test_system_carbon_grid_factor_zero_warns(
+    create_building, create_energy_summary
+):
+    building = create_building(total_floor_area=Decimal("100"))
+    # No electricity EPD -> grid factor 0
+    create_energy_summary(building, cooling_kwh=Decimal("1000"))
+
+    result = get_operational_carbon_by_system(building)
+
+    assert result["labels"] == ["Cooling systems"]
+    assert result["absolute"] == [0.0]
+    assert result["total"] == 0
+    assert result.get("warning") == "grid_factor_zero"
+
+
+@pytest.mark.django_db
+def test_system_carbon_no_energy_summary(create_building):
+    building = create_building(total_floor_area=Decimal("100"))
+    result = get_operational_carbon_by_system(building)
+
+    assert result == {"labels": [], "data": [], "absolute": [], "total": 0}
+
+
+@pytest.mark.django_db
+def test_system_carbon_blank_systems_excluded(
+    create_building, create_electricity_epd, create_operationalproduct, create_energy_summary
+):
+    building = create_building(total_floor_area=Decimal("100"))
+    epd = create_electricity_epd(Decimal("0.5"))
+    create_operationalproduct(building, epd, Decimal("1"), Unit.KWH)
+    # cooling has value; others blank/zero -> excluded
+    create_energy_summary(
+        building, cooling_kwh=Decimal("1000"), ventilation_kwh=Decimal("0")
+    )
+
+    result = get_operational_carbon_by_system(building)
+
+    assert result["labels"] == ["Cooling systems"]
+    assert result["total"] == 5.0

--- a/pages/views/building/building.py
+++ b/pages/views/building/building.py
@@ -125,6 +125,7 @@ def handle_building_load(request, building_id, simulation):
     building = get_object_or_404(
         Building.objects
             .filter(created_by=request.user)
+            .select_related("energy_summary")
             .prefetch_related(
                 # 1) grab each BuildingAssemblyModel …
                 Prefetch(

--- a/pages/views/building/building_stats.py
+++ b/pages/views/building/building_stats.py
@@ -19,6 +19,7 @@ from typing import Dict, Any, List, Optional
 from pages.models.building import Building
 from pages.models.building_operation.chilling import CoolingSystemChiller
 from pages.models.building_operation.air_conditioning import CoolingSystemAirConditioner
+from pages.models.epd import Unit
 from pages.views.building.impact_calculation import calculate_impacts, calculate_impact_operational, ImpactCalculationError
 
 _MAPPING_PATH = os.path.join(
@@ -332,10 +333,20 @@ def get_building_detail_statistics(
         prefetched_operational=prefetched_operational,
     )
 
+    # Per-year operational carbon intensity by system (matches the Systems-tab chart).
+    operational_by_system = get_operational_carbon_by_system(
+        building, prefetched_operational=prefetched_operational
+    )
+
     return {
         'total_carbon_footprint': embodied + operational,
         'total_embodied_carbon': embodied,
         'total_operational_carbon': operational,
+        # Per-year intensity (sum of Systems-tab bars), so the stat card matches the chart.
+        'operational_carbon_per_year': operational_by_system.get('total', 0),
+        'grid_emission_factor': _derive_grid_emission_factor(
+            building, prefetched_operational=prefetched_operational
+        ),
         'carbon_savings_percentage': calculate_carbon_savings_percentage(building),
         'calculation_errors': calculation_errors,
     }
@@ -487,75 +498,143 @@ def get_embodied_carbon_by_material(
     return {'labels': labels, 'data': data, 'absolute': absolute, 'total': chart_total}
 
 
+def _derive_grid_emission_factor(building: Building, prefetched_operational=None) -> Decimal:
+    """
+    Derive the grid emission factor (kgCO2eq/kWh) from the building's electricity EPD.
+
+    The factor equals the electricity EPD's B6 GWP value divided by its declared
+    amount (i.e. the per-kWh carbon intensity used internally by
+    ``calculate_impact_operational`` for the (kWh, kWh) case).
+
+    No dedicated DB field exists for the grid factor; it is computed on the fly.
+
+    Args:
+        building: Building instance to derive the factor for
+        prefetched_operational: Optional pre-fetched operational product list
+
+    Returns:
+        Grid emission factor as a Decimal (kgCO2eq/kWh), or Decimal('0') if no
+        suitable electricity EPD is found.
+    """
+    if prefetched_operational is not None:
+        operational_products = prefetched_operational
+    else:
+        operational_products = building.operational_products.all()
+
+    def _is_electricity(op) -> bool:
+        try:
+            epd = op.epd
+            if epd is None:
+                return False
+            # Primary: kWh-declared electricity entered in kWh
+            if epd.declared_unit == Unit.KWH and op.input_unit == Unit.KWH:
+                return True
+            # Fallback: category name suggests electricity/energy/power
+            category = getattr(epd, "category", None)
+            name = (category.name_en or "").lower() if category else ""
+            return any(token in name for token in ("electr", "energy", "power"))
+        except AttributeError:
+            return False
+
+    electricity_product = next(
+        (op for op in operational_products if _is_electricity(op)), None
+    )
+    if electricity_product is None:
+        return Decimal("0")
+
+    try:
+        epd = electricity_product.epd
+        impact_set = epd.epdimpact_set.filter(impact__life_cycle_stage="b6")
+        gwp_b6 = next(
+            (i.value for i in impact_set if i.impact.impact_category == "gwp"), None
+        )
+        if gwp_b6 is None or not epd.declared_amount:
+            return Decimal("0")
+        return Decimal(str(gwp_b6)) / Decimal(str(epd.declared_amount))
+    except (AttributeError, ZeroDivisionError):
+        return Decimal("0")
+
+
 def get_operational_carbon_by_system(
     building: Building,
     simulated: bool = False,
     prefetched_operational=None,
 ) -> Dict[str, Any]:
     """
-    Calculate operational carbon grouped by system type (cooling, ventilation, etc.).
+    Calculate operational carbon intensity (kgCO2eq/m²/yr) grouped by building system.
+
+    Uses the structured per-system annual energy (EnergySummary) multiplied by the
+    derived grid emission factor and normalised by gross floor area:
+
+        Carbon_intensity_system = system_kWh * Grid_factor / Floor_area
+
+    The result is a per-YEAR intensity (no reference-period multiplier). Systems
+    with no entered (zero/blank) energy are excluded so their chart bar is hidden.
 
     Args:
         building: Building instance to calculate for
-        simulated: If True, calculate for simulated components
-        prefetched_operational: Optional pre-fetched operational product list
+        simulated: Unused (kept for signature compatibility)
+        prefetched_operational: Optional pre-fetched operational product list,
+            used to derive the grid emission factor
 
     Returns:
-        Dictionary with 'labels', 'data', 'absolute', and 'total' for chart rendering
+        Dictionary with 'labels', 'data' (% share of total), 'absolute'
+        (kgCO2eq/m²/yr) and 'total'. May include 'blocked' (floor area missing)
+        or 'warning' (grid factor is zero).
     """
-    carbon_by_system = defaultdict(Decimal)
+    empty = {'labels': [], 'data': [], 'absolute': [], 'total': 0}
 
-    if prefetched_operational is not None:
-        operational_products = prefetched_operational
-    elif simulated:
-        operational_products = building.simulated_operational_products.all()
-    else:
-        operational_products = building.operational_products.all()
+    summary = getattr(building, 'energy_summary', None)
+    if summary is None:
+        return empty
 
-    reference_period = Decimal(str(building.reference_period))
+    floor_area = building.total_floor_area
+    if not floor_area or Decimal(str(floor_area)) == 0:
+        return {**empty, 'blocked': True}
 
-    for op in operational_products:
-        try:
-            system_type = "Other Systems"
-            if op.epd and op.epd.category:
-                category_name = op.epd.category.name_en.lower() if op.epd.category.name_en else ""
+    grid_factor = _derive_grid_emission_factor(building, prefetched_operational)
+    floor_area = Decimal(str(floor_area))
 
-                if 'cool' in category_name or 'refriger' in category_name:
-                    system_type = "Cooling systems"
-                elif 'ventil' in category_name or 'air' in category_name:
-                    system_type = "Ventilation systems"
-                elif 'light' in category_name or 'lamp' in category_name:
-                    system_type = "Lighting systems"
-                elif 'lift' in category_name or 'elevator' in category_name or 'escalator' in category_name:
-                    system_type = "Lift & escalator"
-                elif 'water' in category_name or 'heat' in category_name:
-                    system_type = "Hot Water Systems"
-                elif 'electr' in category_name or 'energy' in category_name or 'power' in category_name:
-                    system_type = "Electricity"
-                elif 'gas' in category_name or 'fuel' in category_name:
-                    system_type = "Gas/Fuel"
+    # Labels must match the substrings used by the Systems-tab JS systemStyleMap.
+    systems = [
+        ("Cooling systems", summary.cooling_kwh),
+        ("Ventilation systems", summary.ventilation_kwh),
+        ("Lighting systems", summary.lighting_kwh),
+        ("Lift & escalator", summary.lift_escalator_kwh),
+        ("Hot Water Systems", summary.hot_water_kwh),
+    ]
 
-            impacts = calculate_impact_operational(op)
-            gwp_b6 = impacts.get('gwp_b6', Decimal('0.0')) * reference_period
-            carbon_by_system[system_type] += gwp_b6
-
-        except (ValueError, AttributeError, ZeroDivisionError):
+    intensity_by_system = []
+    for label, kwh in systems:
+        if kwh is None or Decimal(str(kwh)) <= 0:
             continue
+        intensity = Decimal(str(kwh)) * grid_factor / floor_area
+        intensity_by_system.append((label, intensity))
 
-    sorted_items = sorted(carbon_by_system.items(), key=lambda x: x[1], reverse=True)
-    total = sum(v for _, v in sorted_items) or Decimal('1')
+    if not intensity_by_system:
+        return empty
+
+    intensity_by_system.sort(key=lambda x: x[1], reverse=True)
+    total = sum(value for _, value in intensity_by_system)
 
     labels = []
     data = []
     absolute = []
-    for label, value in sorted_items:
+    for label, value in intensity_by_system:
         labels.append(label)
-        percentage = float((value / total) * 100)
+        percentage = float((value / total) * 100) if total > 0 else 0.0
         data.append(round(percentage, 1))
         absolute.append(round(float(value), 2))
 
-    chart_total = round(float(sum(v for _, v in sorted_items)), 2)
-    return {'labels': labels, 'data': data, 'absolute': absolute, 'total': chart_total}
+    result = {
+        'labels': labels,
+        'data': data,
+        'absolute': absolute,
+        'total': round(float(total), 2),
+    }
+    if grid_factor == 0:
+        result['warning'] = 'grid_factor_zero'
+    return result
 
 
 def get_building_chart_data(

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -576,8 +576,8 @@
                 <p class="text-[13px] font-medium text-[var(--text--sub-600)] leading-5">{% translate "Total Operational Carbon Intensity" %}</p>
               </div>
               <div class="pl-2.5 flex items-baseline mt-1">
-                <span class="text-2xl font-medium">{{ stats.total_operational_carbon|floatformat:2|default:"0" }}</span>
-                <span class="text-sm font-medium text-[var(--text--sub-600)] ml-0.5">kgCO<sub>2</sub>eq/m²</span>
+                <span class="text-2xl font-medium">{{ stats.operational_carbon_per_year|floatformat:2|default:"0" }}</span>
+                <span class="text-sm font-medium text-[var(--text--sub-600)] ml-0.5">kgCO<sub>2</sub>eq/m²/yr</span>
               </div>
             </div>
             <div class="flex flex-col flex-1 min-w-0">
@@ -594,7 +594,7 @@
                 <p class="text-[13px] font-medium text-[var(--text--sub-600)] leading-5">{% translate "Grid Emission Factor" %}</p>
               </div>
               <div class="pl-2.5 flex items-baseline mt-1">
-                <span class="text-2xl font-medium">{{ building.grid_emission_factor|floatformat:2|default:"0" }}</span>
+                <span class="text-2xl font-medium">{{ stats.grid_emission_factor|floatformat:2|default:"0" }}</span>
                 <span class="text-sm font-medium text-[var(--text--sub-600)] ml-0.5">kgCO<sub>2</sub>eq/kWh electricity factor</span>
               </div>
             </div>
@@ -1136,13 +1136,7 @@
         // Build operational-by-system horizontal bar rows (Systems tab)
         const systemBarsContainer = document.getElementById("system-bars-container");
         if (systemBarsContainer) {
-          const systemData = {
-            labels:   ["Cooling systems", "Ventilation systems", "Lighting systems", "Hot Water Systems", "Lift & escalator"],
-            data:     [23.3, 15.1, 8.3, 3.6, 1.4],
-            absolute: [19.16, 13.05, 7.21, 3.16, 1.24],
-            total:    86.55,
-          };
-          // TODO: replace hardcoded data above with: chartData.operational_by_system || { labels: [], data: [], absolute: [], total: 0 }
+          const systemData = chartData.operational_by_system || { labels: [], data: [], absolute: [], total: 0 };
 
           const systemStyleMap = [
             { match: (l) => l.includes("cool") || l.includes("refriger"), icon: "snowflake-fill", color: "#97baff" },
@@ -1164,9 +1158,13 @@
           if (systemData.labels.length === 0) {
             if (emptyEl) emptyEl.classList.remove("hidden");
           } else {
+            // Bar width is relative to the largest system (so the biggest bar fills
+            // the track), while the label shows each system's share of the total.
+            const maxAbs = Math.max(...(systemData.absolute.length ? systemData.absolute : [0]), 0) || 1;
             systemData.labels.forEach(function (label, i) {
               const pct = systemData.data[i] || 0;
               const abs = systemData.absolute[i] || 0;
+              const widthPct = (abs / maxAbs) * 100;
               const style = getSystemStyle(label);
               const absFormatted = abs.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
@@ -1179,7 +1177,7 @@
                 </div>
                 <div class="flex flex-1 gap-2 items-center min-w-0">
                   <div class="relative flex-1 h-[34px] rounded-sm bg-[#f2f2f2] overflow-visible">
-                    <div class="absolute inset-y-0 left-0 rounded-l-sm flex items-center" style="width:${Math.max(pct, 0)}%;background:${style.color}">
+                    <div class="absolute inset-y-0 left-0 rounded-l-sm flex items-center" style="width:${Math.max(widthPct, 0)}%;background:${style.color}">
                       <span class="text-[12px] font-semibold ml-2 text-[var(--text--strong-950)] whitespace-nowrap">${pct}%</span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

The single-building dashboard's **Systems tab** previously rendered a hardcoded demo chart (with a `// TODO` to wire real data). This PR makes it compute **operational carbon by building system** from the building's actual energy data, following the formula spec: per-system carbon intensity in **kgCO₂eq/m²/yr**, shown as horizontal bars with each system's % share of the building total.

## What changed

- **Grid emission factor — derived, not stored.** Added `_derive_grid_emission_factor()` in `building_stats.py`. Rather than adding a DB field, it derives the factor (kgCO₂eq/kWh) from the building's electricity EPD as `B6 GWP value ÷ declared_amount` — the same per-kWh intensity the operational impact calc already uses internally. The electricity product is identified by kWh declared+input units, with a category-name fallback.
- **Per-system calculation from real data.** Rewrote `get_operational_carbon_by_system()` to use the structured `EnergySummary` per-system kWh (cooling / ventilation / lighting / lift & escalator / hot water) and compute `kWh × grid_factor ÷ floor_area`, per-year (no reference-period multiplier). Systems with zero/blank energy are excluded so their bar is hidden; results are sorted descending.
- **Edge cases.** Zero/blank floor area returns a `blocked` result; a zero grid factor returns systems at 0 with a `grid_factor_zero` warning flag.
- **Stats consistency.** Added `operational_carbon_per_year` and `grid_emission_factor` to the building stats so the Systems-tab stat cards match the chart total.
- **Template.** `building.html` now consumes `chartData.operational_by_system`, sizes each bar relative to the largest system (while the label keeps the % share of total), reads the grid factor from `stats` (it previously referenced a non-existent `building.grid_emission_factor` that always showed 0), and the total card now shows the per-year value with a `/yr` unit.
- **Performance.** Added `select_related("energy_summary")` to the building load to avoid an extra query.

## Files

- `pages/views/building/building_stats.py` — grid-factor derivation + per-system calc + stats
- `pages/views/building/building.py` — `select_related("energy_summary")`
- `templates/pages/building/building.html` — Systems-tab wiring, bar sizing, stat cards
- `pages/tests/test_operational_carbon_by_system.py` — new tests

## Testing

- 8 new tests pass (grid-factor derivation; per-system calc; floor-area-zero, grid-factor-zero, no-energy-summary, blank-systems-excluded cases).
- Existing impact tests pass (37) — no regressions.
- `manage.py check` — no issues.

## Notes

- The chart only shows non-zero values when the building has both an **electricity operational product with a B6 GWP** (the grid-factor source) and a populated **EnergySummary**. Without the electricity EPD, bars render at 0 and the data carries a `grid_factor_zero` flag; surfacing that as a visible UI message can be a follow-up.
- Scope is the Systems tab only; the Savings tab was intentionally left unchanged.