### PR TITLE
fix: QA round 2 — city pin nearest-match, zero-value preservation, pe…

### DIFF
--- a/libs/form-validator.js
+++ b/libs/form-validator.js
@@ -184,7 +184,11 @@ class FormValidator {
         fieldContainer.appendChild(errorElement);
       }
     }
-    fieldContainer.classList.add('input-error', 'border-error');
+    if (errors && errors.length > 0) {
+      fieldContainer.classList.add('input-error', 'border-error');
+    } else {
+      fieldContainer.classList.remove('input-error', 'border-error');
+    }
     if (errors && errors.length > 0) {
       // Show error
       field.setAttribute('aria-invalid', 'true');

--- a/libs/geo-location.js
+++ b/libs/geo-location.js
@@ -222,6 +222,46 @@ function notifyChange(el) {
   if (el) el.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+// Haversine distance (km) between two (lat,lon) pairs.
+function _haversineKm(lat1, lon1, lat2, lon2) {
+  const toRad = (d) => (d * Math.PI) / 180;
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+// Find the option in `selectEl` whose data-lat/data-lon is closest to (lat,lon)
+// and within `maxKm` km. Returns the option element or null.
+function findOptionByDistance(selectEl, lat, lon, maxKm = 50) {
+  if (!selectEl || lat == null || lon == null) return null;
+  let best = null;
+  let bestKm = Infinity;
+  for (const opt of selectEl.options) {
+    if (!opt.value) continue;
+    const oLat = parseFloat(opt.getAttribute("data-lat"));
+    const oLon = parseFloat(opt.getAttribute("data-lon"));
+    if (Number.isNaN(oLat) || Number.isNaN(oLon)) continue;
+    const km = _haversineKm(lat, lon, oLat, oLon);
+    if (km < bestKm) {
+      bestKm = km;
+      best = opt;
+    }
+  }
+  return best && bestKm <= maxKm ? best : null;
+}
+
+// Show or hide a non-blocking inline note under the city select indicating
+// that auto-detection failed.
+function _setCityAutopickNote(visible) {
+  const note = document.getElementById("city-autopick-note");
+  if (!note) return;
+  note.style.display = visible ? "" : "none";
+}
+
 // Re-validate geo fields via FormValidator directly, without dispatching DOM events
 // that would re-trigger HTMX cascades and wipe freshly-loaded dropdown values.
 function _revalidateGeoFields(countryEl, regionEl, cityEl) {
@@ -310,7 +350,12 @@ async function selectCurrentLocation() {
     // 2. Load cities for the matched region into #city-select.
     // We use our own htmx.ajax call — do NOT fire notifyChange(regionSelect) here
     // because the region select's own hx-trigger="change" would race against us.
-    await htmx.ajax("GET", "/select_lists/?region=" + regionMatch.value, {
+    // Pass lat/lon so the backend emits data-lat/data-lon for nearest-city fallback.
+    const cityUrl =
+      "/select_lists/?region=" + regionMatch.value +
+      "&lat=" + encodeURIComponent(location.latitude) +
+      "&lon=" + encodeURIComponent(location.longitude);
+    await htmx.ajax("GET", cityUrl, {
       target: "#city-select",
       swap: "innerHTML",
     });
@@ -318,13 +363,26 @@ async function selectCurrentLocation() {
     await new Promise(r => setTimeout(r, 0));
 
     const citySelect = document.getElementById("city-select");
-    const cityMatch = findOptionByNames(citySelect, location.cityCandidates);
+    // Pass 1: match by name (handles cases where Nominatim's city matches the DB row)
+    let cityMatch = findOptionByNames(citySelect, location.cityCandidates);
+    // Pass 2: nearest-city by lat/lon (handles suburbs/neighborhoods Nominatim returns
+    // that aren't in cities_light — pick the closest large city within 50 km)
+    if (!cityMatch) {
+      cityMatch = findOptionByDistance(citySelect, location.latitude, location.longitude, 50);
+      if (cityMatch) {
+        console.log(
+          "[GeoLocation] Picked nearest city by distance:", cityMatch.text
+        );
+      }
+    }
     if (!cityMatch) {
       console.warn("[GeoLocation] No city match for candidates:", location.cityCandidates);
+      _setCityAutopickNote(true);
       _revalidateGeoFields(countrySelect, regionSelect, citySelect);
       return;
     }
     citySelect.value = cityMatch.value;
+    _setCityAutopickNote(false);
     console.log("[GeoLocation] Matched city:", cityMatch.text);
     _revalidateGeoFields(countrySelect, regionSelect, citySelect);
   } catch (err) {

--- a/libs/step-manager.js
+++ b/libs/step-manager.js
@@ -1056,6 +1056,11 @@ class StepManager {
             this.formData['building-information/building-name-location'].building_uuid = buildingUuid;
             this.formData['building-information/building-details'] = result.data;
 
+            // Update persistent project-name header in sidebar
+            if (result.data.building_name) {
+              this.updateProjectName(result.data.building_name);
+            }
+
             // Restore form fields
             Object.keys(result.data).forEach((key) => {
               const element = document.querySelector(
@@ -1199,6 +1204,27 @@ class StepManager {
     }
   }
 
+  /**
+   * Show / hide the persistent project-name header in the wizard sidebar.
+   * @param {string|null|undefined} name
+   */
+  updateProjectName(name) {
+    const label = document.getElementById('project-name-label');
+    const heading = document.getElementById('project-name');
+    if (!label || !heading) return;
+    if (name) {
+      heading.textContent = name;
+      heading.setAttribute('title', name);
+      label.style.display = '';
+      heading.style.display = '';
+    } else {
+      heading.textContent = '';
+      heading.removeAttribute('title');
+      label.style.display = 'none';
+      heading.style.display = 'none';
+    }
+  }
+
   updateCurrentStepInfo() {
     const currentStepInfo = this.getCurrentStepInfo();
     const currentStepTitle = document.getElementById("current-step-title");
@@ -1339,6 +1365,9 @@ class StepManager {
           Toast.success(gettext('Building created successfully!'));
         } else {
           Toast.success(gettext('Building updated successfully!'));
+        }
+        if (saveResult.building_name) {
+          this.updateProjectName(saveResult.building_name);
         }
       }
     }

--- a/pages/views/building/add_building_steps.py
+++ b/pages/views/building/add_building_steps.py
@@ -832,10 +832,20 @@ def save_building_step(request):
         # For all other steps, just acknowledge receipt
         # Operational systems are saved immediately via their dedicated APIs
         # Other data is kept client-side until final completion
+        building_name = None
+        if building_uuid:
+            try:
+                _b = Building.objects.only("name").get(
+                    uuid=uuid_lib.UUID(building_uuid), created_by=request.user
+                )
+                building_name = _b.name
+            except (ValueError, Building.DoesNotExist):
+                pass
         return JsonResponse({
             "success": True,
             "message": "Step data saved successfully",
-            "building_uuid": building_uuid
+            "building_uuid": building_uuid,
+            "building_name": building_name,
         })
 
     except json.JSONDecodeError:
@@ -889,8 +899,8 @@ def get_building_data(request):
             'climate_type': building.climate_zone.name if building.climate_zone else '',
             'assessment_period': building.reference_period,
             'construction_year': building.construction_year,
-            'total_floor_area': str(building.total_floor_area) if building.total_floor_area else '',
-            'conditioned_floor_area': str(building.cond_floor_area) if building.cond_floor_area else '',
+            'total_floor_area': str(building.total_floor_area) if building.total_floor_area is not None else '',
+            'conditioned_floor_area': str(building.cond_floor_area) if building.cond_floor_area is not None else '',
             'floors_above_ground': building.floors_above_ground,
             'floors_below_ground': building.floors_below_ground,
             'has_design_drawings': building.has_design_drawings,

--- a/pages/views/select_lists.py
+++ b/pages/views/select_lists.py
@@ -140,10 +140,22 @@ def select_lists(request):
                 {"items": [], "default_text": "Select a city"},
             )
         cities = CustomCity.objects.filter(region=region_id).order_by("name")
+        # When lat/lon are supplied (map pin), expose them as data-* attributes
+        # on each option so the frontend can pick the nearest city to the pin.
+        try:
+            lat = float(request.GET.get("lat")) if request.GET.get("lat") else None
+            lon = float(request.GET.get("lon")) if request.GET.get("lon") else None
+        except (TypeError, ValueError):
+            lat = lon = None
+        include_coords = lat is not None and lon is not None
         return render(
             request,
             "pages/utils/select_list.html",
-            {"items": cities, "default_text": "Select a city"},
+            {
+                "items": cities,
+                "default_text": "Select a city",
+                "include_coords": include_coords,
+            },
         )
     elif m := request.GET.get("category"):
         category_id = int(m)

--- a/templates/pages/add-building/_base.html
+++ b/templates/pages/add-building/_base.html
@@ -185,6 +185,10 @@
             <span data-icon="close-line" data-size="18"></span>
           </button>
         </div>
+        <p id="project-name-label" class="text-xs font-medium uppercase tracking-widest text-[var(--text--sub-600)] mt-6" style="display:none;">
+          {% translate "Project" %}
+        </p>
+        <h2 id="project-name" class="text-base font-extrabold truncate" title="" style="display:none;"></h2>
         <h1 id="page-title" class="text-base font-extrabold mt-6">{% translate "Add New Building" %}</h1>
         <p id="page-description" class="text-sm font-medium mt-1 text-[var(--text--sub-600)]">
           {% translate "Complete the following steps to add a new building" %}

--- a/templates/pages/add-building/components/building-information/building-name-location.html
+++ b/templates/pages/add-building/components/building-information/building-name-location.html
@@ -139,6 +139,9 @@
       </select>
     </label>
     <p class="validator-hint">{% translate "Select a region first, then choose city" %}</p>
+    <p id="city-autopick-note" class="text-xs text-[var(--text--sub-600)] mt-1" style="display:none;">
+      {% translate "Could not auto-detect the closest city from the map pin — please pick the city manually." %}
+    </p>
   </fieldset>
 
   <!-- Longitude Field (Optional) -->

--- a/templates/pages/add-building/components/operational-details/operational-schedule-temperature.html
+++ b/templates/pages/add-building/components/operational-details/operational-schedule-temperature.html
@@ -137,33 +137,20 @@
         const data = result.data;
 
         // Populate form fields
-        if (data.number_of_residents) {
-          form.querySelector('[name="number_of_residents"]').value = data.number_of_residents;
-        }
-        if (data.annual_operating_hours_per_day) {
-          form.querySelector('[name="annual_operating_hours_per_day"]').value = data.annual_operating_hours_per_day;
-        }
-        if (data.annual_operating_days_per_week) {
-          form.querySelector('[name="annual_operating_days_per_week"]').value = data.annual_operating_days_per_week;
-        }
-        if (data.annual_operating_weeks_per_year) {
-          form.querySelector('[name="annual_operating_weeks_per_year"]').value = data.annual_operating_weeks_per_year;
-        }
-        if (data.room_heating_temperature) {
-          form.querySelector('[name="room_heating_temperature"]').value = data.room_heating_temperature;
-        }
-        if (data.heating_temperature_unit) {
-          form.querySelector('[name="heating_temperature_unit"]').value = data.heating_temperature_unit;
-        }
-        if (data.room_cooling_temperature) {
-          form.querySelector('[name="room_cooling_temperature"]').value = data.room_cooling_temperature;
-        }
-        if (data.cooling_temperature_unit) {
-          form.querySelector('[name="cooling_temperature_unit"]').value = data.cooling_temperature_unit;
-        }
-        if (data.renewable_energy_percent) {
-          form.querySelector('[name="renewable_energy_percent"]').value = data.renewable_energy_percent;
-        }
+        const setIfPresent = (name, value) => {
+          if (value === null || value === undefined || value === '') return;
+          const el = form.querySelector(`[name="${name}"]`);
+          if (el) el.value = value;
+        };
+        setIfPresent('number_of_residents', data.number_of_residents);
+        setIfPresent('annual_operating_hours_per_day', data.annual_operating_hours_per_day);
+        setIfPresent('annual_operating_days_per_week', data.annual_operating_days_per_week);
+        setIfPresent('annual_operating_weeks_per_year', data.annual_operating_weeks_per_year);
+        setIfPresent('room_heating_temperature', data.room_heating_temperature);
+        setIfPresent('heating_temperature_unit', data.heating_temperature_unit);
+        setIfPresent('room_cooling_temperature', data.room_cooling_temperature);
+        setIfPresent('cooling_temperature_unit', data.cooling_temperature_unit);
+        setIfPresent('renewable_energy_percent', data.renewable_energy_percent);
         if (data.building_smart_system !== undefined) {
           const val = data.building_smart_system ? 'yes' : 'no';
           const radio = form.querySelector(`[name="building_smart_system"][value="${val}"]`);

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -241,10 +241,14 @@
                 >{% translate "Carbon Footprint" %}</span
               >
               <div class="flex px-2.5 items-end bg-[#C1DBE3] w-fit">
+                {% if energy_mismatch %}
+                <span class="text-2xl/8 font-medium" title="{% translate 'Hidden until energy totals are reconciled' %}">—</span>
+                {% else %}
                 <span class="text-2xl/8 font-medium">{{ stats.total_carbon_footprint|floatformat:1|default:"0" }}</span>
                 <span class="text-sm/5 font-medium text-[var(--text--sub-600)]"
                   >kgCO<sub>2</sub>eq/m<sup>2</sup></span
                 >
+                {% endif %}
               </div>
             </li>
             <li class="flex flex-col flex-1">
@@ -277,10 +281,14 @@
                 >{% translate "Operational Carbon" %}</span
               >
               <div class="flex px-2.5 items-end bg-[#C1DBE3] w-fit">
+                {% if energy_mismatch %}
+                <span class="text-2xl/8 font-medium" title="{% translate 'Hidden until energy totals are reconciled' %}">—</span>
+                {% else %}
                 <span class="text-2xl/8 font-medium">{{ stats.total_operational_carbon|floatformat:1|default:"0" }}</span>
                 <span class="text-sm/5 font-medium text-[var(--text--sub-600)]"
                   >kgCO<sub>2</sub>eq/m<sup>2</sup></span
                 >
+                {% endif %}
               </div>
             </li>
             {# Carbon Savings hidden — will be re-enabled in a future release #}

--- a/templates/pages/utils/select_list.html
+++ b/templates/pages/utils/select_list.html
@@ -5,6 +5,6 @@
     <option value="{{ item.id }}">{{ item.name }}</option>
   {% else %}
     {# Handle model objects #}
-    <option value="{{ item.id }}">{{ item }}</option>
+    <option value="{{ item.id }}"{% if include_coords and item.latitude is not None and item.longitude is not None %} data-lat="{{ item.latitude }}" data-lon="{{ item.longitude }}"{% endif %}>{{ item }}</option>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary

  Round-2 QA pass against the seven issues raised on the building-creation workflow. Three were already fully
  implemented and verified during audit (energy-mismatch label rename, mismatch block on the Operational Data Entry
  step, 3-state file upload model, structural EPD "added" toast, conditioned-floor-area tooltip). Four had unfinished
  pieces or latent bugs — fixed here. Two were not started — implemented here.

  ## Files changed

  #### 1. `libs/form-validator.js` — *"Conditioned floor area / renewable energy — remove mandatory validation, allow
  zero" ticket*
  - **Bug fixed:** `displayFieldError` unconditionally added `input-error border-error` to the fieldset before deciding
  whether errors existed, so every visible fieldset was painted red on every input event. Re-ordered the branch so the
  classes are added only when `errors.length > 0` and removed otherwise.

  #### 2. `pages/views/building/add_building_steps.py` — *"Conditioned floor area can be zero" + "Persistent project
  name in header" tickets*
  - **Bug fixed:** `'conditioned_floor_area': str(building.cond_floor_area) if building.cond_floor_area else ''` (and
  the same pattern for `total_floor_area`) silently coerced a stored zero back to an empty string on round-trip.
  Switched the guard to `... is not None ...` so `0` is preserved.
  - **Feature added:** The generic step-save response now includes `building_name` alongside `building_uuid`, so the
  wizard sidebar can re-render the persistent header after every save without an extra round-trip.

  #### 3. `templates/pages/add-building/components/operational-details/operational-schedule-temperature.html` —
  *"Conditioned floor area / renewable energy — zero is valid" ticket*
  - **Bug fixed:** Nine `if (data.X) { ... }` guards in `loadExistingData()` silently dropped any value that JavaScript
  treats as falsy — including `0` for renewable-energy-percent. Collapsed them into a single `setIfPresent(name, value)`
   helper that explicitly checks for `null` / `undefined` / `""`.

  #### 4. `templates/pages/building/building.html` — *"Block System Dashboard if totals still mismatch" ticket*
  - **Behaviour gap closed:** The mismatch banner was already in place, but the "Carbon Footprint" and "Operational
  Carbon" pills at the top of the page still rendered the (incorrect, pre-reconciliation) numbers. Wrapped both numeric
  pills in `{% if energy_mismatch %}` → render `—` placeholder; `{% else %}` → render the figure. Matches the spec: "Do
  not display any carbon intensity figure, chart, or breakdown in this state."

  #### 5. `pages/views/select_lists.py` — *"City auto-populate from map pin" ticket*
  - **Feature added:** The `?region=` cascade now accepts optional `lat` / `lon` query params. When present, the
  response sets `include_coords=True` in the template context so the option list can expose each city's coordinates to
  the frontend.

  #### 6. `templates/pages/utils/select_list.html` — *"City auto-populate from map pin" ticket*
  - **Feature added:** Each `<option>` now emits `data-lat="…" data-lon="…"` when the view passes `include_coords=True`
  and the model exposes `latitude` / `longitude` (CustomCity proxies cities_light's `City`, which already stores them).

  #### 7. `libs/geo-location.js` — *"City auto-populate from map pin" ticket*
  - **Feature added:** `_haversineKm(lat1, lon1, lat2, lon2)` and `findOptionByDistance(selectEl, lat, lon, maxKm=50)`
  helpers.
  - **Behaviour added:** `selectCurrentLocation` now appends `&lat=…&lon=…` to the city HTMX call. After the swap, if
  name-based `findOptionByNames()` misses (e.g. Nominatim returned "Kakkanad" but the DB only has "Kochi"), it falls
  back to the nearest option within 50 km. If both passes miss, it surfaces an inline `#city-autopick-note` so the user
  knows the system tried and they need to pick manually.

  #### 8. `templates/pages/add-building/components/building-information/building-name-location.html` — *"City
  auto-populate from map pin" ticket*
  - **UI added:** A hidden `<p id="city-autopick-note">` directly below the city `<select>`. `geo-location.js` toggles
  its visibility on/off depending on whether the cascade resolved a city.

  #### 9. `templates/pages/add-building/_base.html` — *"Persistent project name in header" ticket*
  - **UI added:** A small "PROJECT" label + bold `<h2 id="project-name">` slot in the wizard sidebar above the existing
  step title. Hidden by default; revealed only once a building name is known.

  #### 10. `libs/step-manager.js` — *"Persistent project name in header" ticket*
  - **Method added:** `updateProjectName(name)` toggles the new sidebar slot. Called from two places: (a) after a
  successful step-save when `saveResult.building_name` is present, (b) during initial load when `/building/step/data`
  returns the building record (so re-entering the wizard via `?building_uuid=` shows the name immediately).


  ## Issues already fixed in the branch (verified during audit, no further work)

  Grouped by the QA ticket they came from. These are recorded so the reviewer doesn't think they were missed.

  - **Energy consumption mismatch validation.** Label rename to "Total annual energy consumption from building systems"
  is already at `templates/.../energy-consumption-summary.html:147`. Client-side mismatch block on the Operational Data
  Entry step is already at `libs/step-manager.js:1274-1323` using the exact `max(2000, systems_total * 0.05)` tolerance
  from the spec. Server-side mismatch banner on the building detail page is already at
  `templates/pages/building/building.html:577-590` (the missing piece was the pill gating, fixed above).
  - **EPD added confirmation.** Already implemented for structural EPDs — `Toast.success('EPD added successfully')`
  fires from the `htmx:afterRequest` listener at `templates/.../building-structural-components.html:1481-1483`.
  Operational energy carriers use HX-Trigger / form swap and surface their state via the existing "saved" indicator.
  - **Optional file upload for design drawings and BoQ.** Full 3-state model exists: `DocumentStatus` enum
  (`pages/models/building.py:206-222`) with `not_available` / `available_pending` / `uploaded`; migration
  `0044_add_document_status_fields.py`; UI flow with the "Upload now / Skip for now" sub-prompt at
  `templates/.../building-details.html:220-338`; upload endpoint at
  `pages/views/building/building_step_files.py:61-240`; the "marked as available, not yet uploaded — Upload now" inline
  note at `templates/pages/building/building.html:288-302`.
  - **Conditioned floor area tooltip.** Already populated at `templates/.../building-details.html:131-135` with the
  exact spec text ("Conditioned floor area is the portion of the total floor area that is actively heated, cooled, or
  mechanically ventilated.")
  - **Operating Schedule defaults from building type/sub-type.** Backend is complete: Excel reader with `@lru_cache` at
  `pages/schedule_defaults.py`, JSON endpoint at `building_step_operational_schedule.py:141-166` keyed on country (India
   / ALCBT-CAM-IDN-THA-VNM) + type + sub-type. Frontend on the Operational Schedule step applies the defaults in
  italic/grey, reverts to normal text on user edit, and shows the "No default schedule found…" hint when the lookup
  misses. The Excel file lives in `docs/BEAT_Operating_Schedule_Defaults.xlsx` per the spec.


  ## Notes / findings not changed

  - **Auto-populate trigger is on the Operational Schedule step, not on Building Details.** The spec wants schedule
  defaults to fire "when the user selects a building type and sub-type in the Building Details sheet." Today the
  defaults only fire when the user *arrives at* the Operational Schedule step (which reads building type from the DB).
  Functionally equivalent because the defaults are derived from data already persisted by the Building Details step, but
   the visual moment-of-truth is different. Not changing without product confirmation — the current behaviour is
  arguably better (it keeps the Building Details step uncluttered).
  - **City auto-populate ≤ 50 km threshold is a guess.** Picked because cities_light typically stores cities of >15k
  population, and most regional Nominatim hits sit within that radius of the nearest stored city. Trivially tunable in
  `findOptionByDistance(…, maxKm)` if QA reports false matches in dense regions (Bangkok metro, NCR Delhi).
  - **`libs/_icons-registry.js` and `static/css/output.css` had uncommitted modifications** in the working tree before
  this session. They look like build artifacts and were not touched — they remain unstaged so they don't pollute this
  PR.
  - **`pages/geo_lookup.py` is still untracked** in git. It's referenced by the operational schedule defaults /
  climate-zone resolution and was added in the previous `a994169` commit's working set but apparently never staged.
  Worth confirming whether it should be tracked in a follow-up commit.


  ## Test plan

  - [x] Drop a map pin on Bangkok, Mumbai, Hanoi, Jakarta. Country + Region + City should auto-fill, or the new inline
  note ("Could not auto-detect the closest city…") should appear.
  - [x] On Building Details, save with conditioned floor area `0` and again with empty. No red border in either case;
  both round-trip correctly when re-entering the wizard.
  - [x] On the Operational Schedule step, save with renewable-energy `0`. Re-enter the step — the `0` should still be
  there.
  - [x] Create a building with energy totals 16,800 kWh (systems) vs 208,361 kWh (carriers). Navigate directly to the
  building dashboard URL. Banner must render and both "Carbon Footprint" and "Operational Carbon" pills must show `—`.
  Reconcile to ±2000 kWh — pills must render the real numbers.
  - [x] Name a building "Test Building Kerala 2". Header in the wizard sidebar must show that name on every subsequent
  step. Re-enter the wizard via `?building_uuid=…` — name must appear on first load.
  - [x] Add a structural EPD — toast already worked, still works.
  - [x] Pick `Yes → Skip for now` for design drawings. Save. View building dashboard — "Design drawings — marked as
  available, not yet uploaded. Upload now" appears.