### PR TITLE
fix: graceful PDF export fallback and Optimization Strategies UI polish

### DIFF
--- a/pages/views/building/building_report.py
+++ b/pages/views/building/building_report.py
@@ -217,10 +217,9 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
     material_data = get_embodied_carbon_by_material(building)
     operational_data = get_operational_carbon_by_system(building)
 
-    # AI narratives are optional enrichment. If generation is unavailable
-    # (no REPORT_API_KEY) or fails, fall back to the built-in narrative text
-    # baked into the PDF/DOCX builders rather than failing the whole export.
-    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data) or {}
+    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data)
+    if ai is None:
+        raise RuntimeError("AI narrative generation failed")
 
     def fmt(val):
         return f"{val:,.1f}"
@@ -248,11 +247,11 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
         "card_material": card_material,
         "card_savings": card_savings,
         # AI-generated narratives (fall back to None if generation failed)
-        "ai_section_2_narrative": ai.get("section_2_narrative"),
-        "ai_section_3_material_insight": ai.get("section_3_material_insight"),
-        "ai_section_4_operational_insight": ai.get("section_4_operational_insight"),
-        "ai_section_5_benchmark_callout": ai.get("section_5_benchmark_callout"),
-        "ai_section_5_strategies": ai.get("section_5_strategies"),
+        "ai_section_2_narrative": ai["section_2_narrative"],
+        "ai_section_3_material_insight": ai["section_3_material_insight"],
+        "ai_section_4_operational_insight": ai["section_4_operational_insight"],
+        "ai_section_5_benchmark_callout": ai["section_5_benchmark_callout"],
+        "ai_section_5_strategies": ai["section_5_strategies"],
     }
 
 
@@ -556,29 +555,6 @@ def _pdf_html(ctx):
     floors_below = b.floors_below_ground if b.floors_below_ground is not None else None
     cond_area = f"{b.cond_floor_area} m&#178;" if b.cond_floor_area else None
 
-    # AI narratives are optional — fall back to static copy when unavailable so
-    # the PDF never renders the literal string "None".
-    s2_narrative = ctx["ai_section_2_narrative"] or (
-        f"Operational carbon accounts for {ctx['op_pct']}% of the total carbon footprint "
-        f"({ctx['operational_carbon']} kgCO<sub>2</sub>eq/m&#178;), with embodied carbon contributing the "
-        f"remaining {ctx['em_pct']}% ({ctx['embodied_carbon']} kgCO<sub>2</sub>eq/m&#178;). Because embodied "
-        "carbon is released upfront during construction, reducing it delivers immediate emissions savings."
-    )
-    s3_material_insight = ctx["ai_section_3_material_insight"] or (
-        "Concrete and reinforcement typically dominate embodied carbon in reinforced-concrete-frame "
-        "buildings. Specifying low-carbon concrete mixes (GGBS or fly ash blends), using recycled-content "
-        "reinforcement, and minimising structural over-design are the highest-impact reduction strategies."
-    )
-    s4_operational_insight = ctx["ai_section_4_operational_insight"] or (
-        "Cooling is typically the dominant operational carbon contributor, driven primarily by air "
-        "conditioning systems, followed by ventilation and lighting loads."
-    )
-    s5_benchmark_callout = ctx["ai_section_5_benchmark_callout"] or (
-        f"This building's total carbon footprint is {ctx['total_carbon']} kgCO<sub>2</sub>eq/m&#178;. "
-        "Compare against best-practice and national-average figures for buildings of this type and region "
-        "to identify the largest reduction opportunities."
-    )
-
     return f"""<!DOCTYPE html>
 <html>
 <head>
@@ -705,7 +681,7 @@ def _pdf_html(ctx):
 {ctx["donut_card"]}
 <p class="fig-caption">Figure 1 &#8212; Whole life carbon cycle of the building</p>
 
-<p class="body-text">{s2_narrative}</p>
+<p class="body-text">{ctx["ai_section_2_narrative"]}</p>
 
 <!-- ===== PAGE 4: SECTION 3 ===== -->
 <div class="page-break"></div>
@@ -728,7 +704,7 @@ def _pdf_html(ctx):
 {_chart_img(ctx["card_material"], "88%")}
 <p class="fig-caption">Figure 3 &#8212; Embodied carbon by material (Materials tab)</p>
 
-<p class="body-text">{s3_material_insight}</p>
+<p class="body-text">{ctx["ai_section_3_material_insight"]}</p>
 
 <!-- ===== PAGE 5: SECTION 4 — OPERATIONAL CARBON ===== -->
 <div class="page-break"></div>
@@ -745,7 +721,7 @@ def _pdf_html(ctx):
 
 <p class="fig-caption" style="margin-top:80pt;">Figure 4 &#8212; Operational carbon by system and appliance (Energy tab)</p>
 
-<p class="body-text">{s4_operational_insight}</p>
+<p class="body-text">{ctx["ai_section_4_operational_insight"]}</p>
 
 <!-- ===== PAGE 6: SECTION 5 — BENCHMARKING ===== -->
 <div class="page-break"></div>
@@ -783,7 +759,7 @@ def _pdf_html(ctx):
   </tr>
 </table>
 
-<div class="callout">{s5_benchmark_callout}</div>
+<div class="callout">{ctx["ai_section_5_benchmark_callout"]}</div>
 
 <p class="subsection-heading">5.3 &nbsp; Optimisation Strategies</p>
 
@@ -1361,11 +1337,7 @@ def _build_docx(ctx):
     callout5.paragraph_format.space_after = Pt(14)
     pPr5 = callout5._p.get_or_add_pPr()
     shd5 = OxmlElement("w:shd"); shd5.set(qn("w:val"), "clear"); shd5.set(qn("w:color"), "auto"); shd5.set(qn("w:fill"), "EFF6FF"); pPr5.append(shd5)
-    cr5 = callout5.add_run(ctx["ai_section_5_benchmark_callout"] or (
-        f"This building's total carbon footprint is {ctx['total_carbon']} kgCO₂eq/m². Compare against "
-        "best-practice and national-average figures for buildings of this type and region to identify the "
-        "largest reduction opportunities."
-    ))
+    cr5 = callout5.add_run(ctx["ai_section_5_benchmark_callout"])
     cr5.font.size = Pt(9); cr5.font.color.rgb = RGBColor(0x1D, 0x6F, 0xA8)
 
     # ── Section 5.3: Optimisation Strategies ─────────────────────────────────

--- a/pages/views/building/building_report.py
+++ b/pages/views/building/building_report.py
@@ -217,9 +217,10 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
     material_data = get_embodied_carbon_by_material(building)
     operational_data = get_operational_carbon_by_system(building)
 
-    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data)
-    if ai is None:
-        raise RuntimeError("AI narrative generation failed")
+    # AI narratives are optional enrichment. If generation is unavailable
+    # (no REPORT_API_KEY) or fails, fall back to the built-in narrative text
+    # baked into the PDF/DOCX builders rather than failing the whole export.
+    ai = _generate_ai_narratives(building, stats, assembly_data, material_data, operational_data) or {}
 
     def fmt(val):
         return f"{val:,.1f}"
@@ -247,11 +248,11 @@ def _build_context(building, request, card_donut="", card_assembly="", card_mate
         "card_material": card_material,
         "card_savings": card_savings,
         # AI-generated narratives (fall back to None if generation failed)
-        "ai_section_2_narrative": ai["section_2_narrative"],
-        "ai_section_3_material_insight": ai["section_3_material_insight"],
-        "ai_section_4_operational_insight": ai["section_4_operational_insight"],
-        "ai_section_5_benchmark_callout": ai["section_5_benchmark_callout"],
-        "ai_section_5_strategies": ai["section_5_strategies"],
+        "ai_section_2_narrative": ai.get("section_2_narrative"),
+        "ai_section_3_material_insight": ai.get("section_3_material_insight"),
+        "ai_section_4_operational_insight": ai.get("section_4_operational_insight"),
+        "ai_section_5_benchmark_callout": ai.get("section_5_benchmark_callout"),
+        "ai_section_5_strategies": ai.get("section_5_strategies"),
     }
 
 
@@ -555,6 +556,29 @@ def _pdf_html(ctx):
     floors_below = b.floors_below_ground if b.floors_below_ground is not None else None
     cond_area = f"{b.cond_floor_area} m&#178;" if b.cond_floor_area else None
 
+    # AI narratives are optional — fall back to static copy when unavailable so
+    # the PDF never renders the literal string "None".
+    s2_narrative = ctx["ai_section_2_narrative"] or (
+        f"Operational carbon accounts for {ctx['op_pct']}% of the total carbon footprint "
+        f"({ctx['operational_carbon']} kgCO<sub>2</sub>eq/m&#178;), with embodied carbon contributing the "
+        f"remaining {ctx['em_pct']}% ({ctx['embodied_carbon']} kgCO<sub>2</sub>eq/m&#178;). Because embodied "
+        "carbon is released upfront during construction, reducing it delivers immediate emissions savings."
+    )
+    s3_material_insight = ctx["ai_section_3_material_insight"] or (
+        "Concrete and reinforcement typically dominate embodied carbon in reinforced-concrete-frame "
+        "buildings. Specifying low-carbon concrete mixes (GGBS or fly ash blends), using recycled-content "
+        "reinforcement, and minimising structural over-design are the highest-impact reduction strategies."
+    )
+    s4_operational_insight = ctx["ai_section_4_operational_insight"] or (
+        "Cooling is typically the dominant operational carbon contributor, driven primarily by air "
+        "conditioning systems, followed by ventilation and lighting loads."
+    )
+    s5_benchmark_callout = ctx["ai_section_5_benchmark_callout"] or (
+        f"This building's total carbon footprint is {ctx['total_carbon']} kgCO<sub>2</sub>eq/m&#178;. "
+        "Compare against best-practice and national-average figures for buildings of this type and region "
+        "to identify the largest reduction opportunities."
+    )
+
     return f"""<!DOCTYPE html>
 <html>
 <head>
@@ -681,7 +705,7 @@ def _pdf_html(ctx):
 {ctx["donut_card"]}
 <p class="fig-caption">Figure 1 &#8212; Whole life carbon cycle of the building</p>
 
-<p class="body-text">{ctx["ai_section_2_narrative"]}</p>
+<p class="body-text">{s2_narrative}</p>
 
 <!-- ===== PAGE 4: SECTION 3 ===== -->
 <div class="page-break"></div>
@@ -704,7 +728,7 @@ def _pdf_html(ctx):
 {_chart_img(ctx["card_material"], "88%")}
 <p class="fig-caption">Figure 3 &#8212; Embodied carbon by material (Materials tab)</p>
 
-<p class="body-text">{ctx["ai_section_3_material_insight"]}</p>
+<p class="body-text">{s3_material_insight}</p>
 
 <!-- ===== PAGE 5: SECTION 4 — OPERATIONAL CARBON ===== -->
 <div class="page-break"></div>
@@ -721,7 +745,7 @@ def _pdf_html(ctx):
 
 <p class="fig-caption" style="margin-top:80pt;">Figure 4 &#8212; Operational carbon by system and appliance (Energy tab)</p>
 
-<p class="body-text">{ctx["ai_section_4_operational_insight"]}</p>
+<p class="body-text">{s4_operational_insight}</p>
 
 <!-- ===== PAGE 6: SECTION 5 — BENCHMARKING ===== -->
 <div class="page-break"></div>
@@ -759,7 +783,7 @@ def _pdf_html(ctx):
   </tr>
 </table>
 
-<div class="callout">{ctx["ai_section_5_benchmark_callout"]}</div>
+<div class="callout">{s5_benchmark_callout}</div>
 
 <p class="subsection-heading">5.3 &nbsp; Optimisation Strategies</p>
 
@@ -1337,7 +1361,11 @@ def _build_docx(ctx):
     callout5.paragraph_format.space_after = Pt(14)
     pPr5 = callout5._p.get_or_add_pPr()
     shd5 = OxmlElement("w:shd"); shd5.set(qn("w:val"), "clear"); shd5.set(qn("w:color"), "auto"); shd5.set(qn("w:fill"), "EFF6FF"); pPr5.append(shd5)
-    cr5 = callout5.add_run(ctx["ai_section_5_benchmark_callout"])
+    cr5 = callout5.add_run(ctx["ai_section_5_benchmark_callout"] or (
+        f"This building's total carbon footprint is {ctx['total_carbon']} kgCO₂eq/m². Compare against "
+        "best-practice and national-average figures for buildings of this type and region to identify the "
+        "largest reduction opportunities."
+    ))
     cr5.font.size = Pt(9); cr5.font.color.rgb = RGBColor(0x1D, 0x6F, 0xA8)
 
     # ── Section 5.3: Optimisation Strategies ─────────────────────────────────

--- a/templates/pages/building/building.html
+++ b/templates/pages/building/building.html
@@ -378,14 +378,14 @@
                   </div>
                   <div style="display:flex;flex-direction:column;gap:4px;">
                     <span style="font-size:13px;font-weight:500;color:#0f172a;white-space:nowrap;">Best Practice</span>
-                    <span style="font-size:13px;font-weight:700;color:#0f172a;background:#4EDF81;padding:2px 6px;white-space:nowrap;">{{ benchmark_position.best_practice|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup></span>
+                    <span style="font-size:13px;font-weight:700;color:#0f172a;background:#4EDF81;padding:2px 6px;white-space:nowrap;">{{ benchmark_position.best_practice|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup></span>
                   </div>
                 </div>
 
                 <!-- Your building -->
                 <div style="position:absolute;top:0;left:{{ benchmark_position.position_pct }}%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;">
                   <div style="font-size:13px;font-weight:500;color:#0f172a;white-space:nowrap;">Your Building</div>
-                  <div style="background:#0f172a;color:#ffffff;font-size:11px;font-weight:800;padding:2px 6px;white-space:nowrap;">{{ stats.total_embodied_carbon|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup></div>
+                  <div style="background:#0f172a;color:#ffffff;font-size:11px;font-weight:800;padding:2px 6px;white-space:nowrap;">{{ stats.total_embodied_carbon|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup></div>
                   <div style="width:2px;height:13px;background:#000;"></div>
                   <div style="width:8px;height:8px;background:#000;border-radius:50%;"></div>
                 </div>
@@ -398,7 +398,7 @@
                   </div>
                   <div style="display:flex;flex-direction:column;gap:4px;">
                     <span style="font-size:13px;font-weight:500;color:#0f172a;white-space:nowrap;">National Avg</span>
-                    <span style="font-size:13px;font-weight:700;color:#0f172a;background:#FECBC9;padding:2px 6px;white-space:nowrap;">{{ benchmark_position.national_average|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup></span>
+                    <span style="font-size:13px;font-weight:700;color:#0f172a;background:#FECBC9;padding:2px 6px;white-space:nowrap;">{{ benchmark_position.national_average|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup></span>
                   </div>
                 </div>
               </div>
@@ -497,11 +497,11 @@
                           <span style="font-size:12px;color:#64748b;white-space:nowrap;margin-left:8px;">{{ item.share_pct|floatformat:1 }}% of total</span>
                         </div>
                         <div style="display:flex;height:32px;width:100%;border-radius:6px;overflow:hidden;font-size:11px;font-weight:500;color:#0f172a;background:#f1f5f9;">
-                          <div style="background:#FFA468;width:{{ item.baseline_bar_pct }}%;display:flex;align-items:center;padding:0 10px;white-space:nowrap;overflow:hidden;">{{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup></div>
-                          {% if item.has_reduction %}<div style="background:#86EFAC;width:{{ item.saving_bar_pct }}%;display:flex;align-items:center;justify-content:center;white-space:nowrap;overflow:hidden;">-{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup></div>{% endif %}
+                          <div style="background:#FFA468;width:{{ item.baseline_bar_pct }}%;display:flex;align-items:center;padding:0 10px;white-space:nowrap;overflow:hidden;">{{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup></div>
+                          {% if item.has_reduction %}<div style="background:#86EFAC;width:{{ item.saving_bar_pct }}%;display:flex;align-items:center;justify-content:center;white-space:nowrap;overflow:hidden;">-{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup></div>{% endif %}
                         </div>
                         {% if item.has_reduction %}
-                        <p style="font-size:12px;color:#0f172a;margin:0;line-height:1.5;"><span style="font-weight:700;color:#16A34A;">{{ item.reduction_pct_display }}%</span> {{ item.method }} <span style="color:#64748b;">• {{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup> → {{ item.optimised_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup> (−{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>)</span></p>
+                        <p style="font-size:12px;color:#0f172a;margin:0;line-height:1.5;"><span style="font-weight:700;color:#16A34A;">{{ item.reduction_pct_display }}%</span> {{ item.method }} <span style="color:#64748b;">• {{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup> → {{ item.optimised_ec|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup> (−{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup>)</span></p>
                         {% endif %}
                       </div>
                       {% endfor %}

--- a/templates/pages/building/savings_tab.html
+++ b/templates/pages/building/savings_tab.html
@@ -38,7 +38,7 @@
           <div class="space-y-1 flex flex-col">
             <span class="text-sm font-medium text-[var(--text--strong-950)]">{% translate "Best Practice" %}</span>
             <span class="text-sm font-bold text-[var(--text--strong-950)] bg-[#4EDF81] px-1 py-0.5">{{ benchmark_position.best_practice|floatformat:0 }}
-              kgCO<sub>2</sub>e/m<sup>2</sup></span>
+              kgCO<sub>2</sub>eq/m<sup>2</sup></span>
           </div>
         </div>
 
@@ -47,7 +47,7 @@
              style="left: {{ benchmark_position.position_pct }}%;">
           <div class="text-base text-[var(--text--strong-950)] w-max text-center">{% translate "Your Building" %}</div>
           <div class="bg-[var(--text--strong-950)] text-white text-xs font-extrabold px-1 py-0.5">
-            {{ stats.total_embodied_carbon|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>
+            {{ stats.total_embodied_carbon|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup>
           </div>
           <div class="grid grid-cols-1 place-items-center gap-0">
             <div class="h-3.25 w-0.5 bg-black"></div>
@@ -64,7 +64,7 @@
           <div class="space-y-1 flex flex-col">
             <span class="text-sm font-medium text-[var(--text--strong-950)]">{% translate "National Avg" %}</span>
             <span class="text-sm font-bold text-[var(--text--strong-950)] bg-[#FECBC9] px-1 py-0.5">{{ benchmark_position.national_average|floatformat:0 }}
-              kgCO<sub>2</sub>e/m<sup>2</sup></span>
+              kgCO<sub>2</sub>eq/m<sup>2</sup></span>
           </div>
         </div>
       </div>
@@ -188,11 +188,11 @@
             <div class="flex items-center gap-1.5">
               <span class="size-2 rounded-full bg-[var(--savings-primary)]"></span>
 
-              <span class="text-[var(--text--sub-600)]">{% translate "Baseline" %}</span>
+              <span class="text-[var(--text--sub-600)]">{% translate "Baseline savings (kgCO₂eq/m²)" %}</span>
             </div>
             <div class="flex items-center gap-1.5">
               <span class="size-2 rounded-full bg-[#4ADE80]"></span>
-              <span class="text-[var(--text--sub-600)]">{% translate "Potential savings" %}</span>
+              <span class="text-[var(--text--sub-600)]">{% translate "Potential savings (kgCO₂eq/m²)" %}</span>
             </div>
           </div>
 
@@ -207,15 +207,17 @@
                 </div>
                 <span class="text-xs font-semibold text-[var(--text--sub-600)]">{{ item.share_pct|floatformat:1 }}% {% translate "of total" %}</span>
               </div>
-              <div class="flex h-8 w-full rounded-md overflow-hidden text-[10px] font-medium text-[var(--text--strong-950)] bg-[var(--bg--weak-100)]">
-                <div class="bg-[var(--savings-primary)] flex items-center px-2 overflow-hidden whitespace-nowrap"
-                     style="width: {{ item.baseline_bar_pct }}%;">
-                  {{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>
+              <div class="flex h-8 w-full rounded-md text-[10px] font-medium text-[var(--text--strong-950)] bg-[var(--bg--weak-100)]">
+                <div class="bg-[var(--savings-primary)] flex items-center px-2 whitespace-nowrap overflow-hidden"
+                     style="width: {{ item.baseline_bar_pct }}%; border-top-left-radius:0.375rem; border-bottom-left-radius:0.375rem;"
+                     title="{{ item.baseline_ec|floatformat:0 }} kgCO₂eq/m²">
+                  {{ item.baseline_ec|floatformat:0 }}
                 </div>
                 {% if item.has_reduction %}
-                <div class="bg-[var(--savings-primary-secondary)] flex items-center justify-center overflow-hidden whitespace-nowrap"
-                     style="width: {{ item.saving_bar_pct }}%;">
-                  -{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>
+                <div class="savings-bar bg-[var(--savings-primary-secondary)] flex items-center justify-center whitespace-nowrap relative"
+                     style="width: {{ item.saving_bar_pct }}%; border-top-right-radius:0.375rem; border-bottom-right-radius:0.375rem;"
+                     title="-{{ item.potential_saving|floatformat:0 }} kgCO₂eq/m²">
+                  <span class="savings-bar-label px-1">-{{ item.potential_saving|floatformat:0 }}</span>
                 </div>
                 {% endif %}
               </div>
@@ -225,9 +227,9 @@
                 <p class="text-[var(--text--strong-950)] max-w-[85%]">
                   <span class="font-bold text-[#16A34A]">{{ item.reduction_pct_display }}%</span>
                   {{ item.method }}
-                  <span class="text-[var(--text--sub-600)]">• {{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>
-                    → {{ item.optimised_ec|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>
-                    (−{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>e/m<sup>2</sup>)</span>
+                  <span class="text-[var(--text--sub-600)]">• {{ item.baseline_ec|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup>
+                    → {{ item.optimised_ec|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup>
+                    (−{{ item.potential_saving|floatformat:0 }} kgCO<sub>2</sub>eq/m<sup>2</sup>)</span>
                 </p>
               </div>
               {% endif %}
@@ -641,6 +643,30 @@
       });
     }
 
+
+    // Overflow savings-bar labels to the right of the bar when the bar is
+    // too narrow to fit the label inside it (Optimization Strategies panel).
+    function adjustSavingsBarLabels() {
+      document.querySelectorAll('.savings-bar').forEach(function (bar) {
+        var label = bar.querySelector('.savings-bar-label');
+        if (!label) return;
+        // Reset to inside state before measuring
+        label.classList.remove('savings-bar-label--outside');
+        label.style.position = '';
+        label.style.left = '';
+        label.style.marginLeft = '';
+        label.style.color = '';
+        // If the label is wider than the bar it lives in, push it outside
+        if (label.scrollWidth > bar.clientWidth) {
+          label.style.position = 'absolute';
+          label.style.left = '100%';
+          label.style.marginLeft = '4px';
+          label.style.color = 'var(--text--strong-950)';
+        }
+      });
+    }
+    adjustSavingsBarLabels();
+    window.addEventListener('resize', adjustSavingsBarLabels);
 
     // Toggle Logic
     window.toggleSavingsView = (view, btn) => {

--- a/templates/pages/home/partials/buildings_list.html
+++ b/templates/pages/home/partials/buildings_list.html
@@ -82,7 +82,7 @@
                     >{% translate "Total carbon footprint" %}</span
                   >
                   <span class="text-base/6 font-medium"
-                    >{{ building.stats.total_carbon_footprint|floatformat:"1" }} kgCO2e eq/m<sup>2</sup></span
+                    >{{ building.stats.total_carbon_footprint|floatformat:"1" }} kgCO<sub>2</sub>eq/m<sup>2</sup></span
                   >
                 </li>
                 <li
@@ -106,7 +106,7 @@
                   >
                   <span
                     class="text-base/6 font-medium text-[var(--text--sub-600)]"
-                    >{{ building.stats.total_embodied_carbon|floatformat:"1" }} kgCO2e eq/m<sup>2</sup></span
+                    >{{ building.stats.total_embodied_carbon|floatformat:"1" }} kgCO<sub>2</sub>eq/m<sup>2</sup></span
                   >
                 </li>
                 <li
@@ -116,9 +116,10 @@
                     class="text-xs/4 font-medium text-[var(--text--sub-600)]"
                     >{% translate "Carbon Savings" %}</span
                   >
+                  {# Carbon savings figure withheld pending methodology review — shown as ---- for now #}
                   <span
                     class="text-base/6 font-medium text-[var(--text--sub-600)]"
-                    >{{ building.stats.carbon_savings_percentage|floatformat:"1" }}%</span
+                    >----</span
                   >
                 </li>
               </ul>


### PR DESCRIPTION
### Summary
Addresses three QA tickets: the PDF/report export 500 error, the Optimization Strategies panel UI issues, and the nonsensical carbon-savings percentage on building cards.

### What & why

**1. Report export no longer 500s** ([building_report.py](pages/views/building/building_report.py))
Production logs showed the export failing with a 500 whenever OpenAI returned `401 invalid_api_key`:
```
AI narrative generation failed: Error code: 401 - Incorrect API key provided...
Report generation failed for building ...: AI narrative generation failed
Internal Server Error: /building/.../export/  → 500
```

**2. Optimization Strategies panel** ([savings_tab.html](templates/pages/building/savings_tab.html))
- Savings label now overflows to the right of the bar (positioned via a small `adjustSavingsBarLabels()` pass) when the bar is too narrow — never clipped or hidden (fixes Pre-cast concrete / Steel / Masonry rows).
- Bars show the number only; the full `kgCO₂eq/m²` value appears on hover via `title` tooltip.
- Legend updated to **"Baseline savings (kgCO₂eq/m²)"** and **"Potential savings (kgCO₂eq/m²)"**.
- Unit notation normalised `kgCO₂e/m²` → `kgCO₂eq/m²` across the panel, benchmark markers, the [building.html](templates/pages/building/building.html) export-card replica (used for the PDF screenshot), and the home building cards — including a malformed `kgCO2e eq/m²` typo fix.
- Corner radii use inline styles (`border-radius:0.375rem`) rather than `rounded-l/r-md`, which are not present in the compiled `output.css`, so no Tailwind rebuild is required.

**3. Carbon savings percentage** ([buildings_list.html](templates/pages/home/partials/buildings_list.html))
The figure was showing implausible values (e.g. 99.4%). Per direction, the home building card now shows `----` pending a methodology review. (The single-building dashboard summary already had this field hidden.)


### Follow-up
- Provision a valid `REPORT_API_KEY` on QA/prod to re-enable AI narratives (export works without it now, using static copy).