### PR TITLE
fix: re-promote toast popover so it stays above stacked dialogs

### DIFF
--- a/libs/toast.js
+++ b/libs/toast.js
@@ -38,15 +38,24 @@ class ToastNotification {
             container.style.pointerEvents = 'none';
 
             if ('popover' in HTMLElement.prototype) {
-                // Top-layer promotion: appears above showModal() dialogs
                 container.popover = 'manual';
                 parent.appendChild(container);
-                container.showPopover();
             } else {
                 // Fallback for browsers without Popover API
                 container.style.zIndex = '999999';
                 parent.appendChild(container);
             }
+        }
+
+        // Top-layer promotion: re-promote on every call so the container
+        // jumps back to the top of the top-layer stack, above any <dialog>
+        // opened via showModal() *after* the container was first created
+        // (the top layer is ordered by promotion time, not just presence in it).
+        if ('popover' in HTMLElement.prototype) {
+            if (container.matches(':popover-open')) {
+                container.hidePopover();
+            }
+            container.showPopover();
         }
 
         return container;


### PR DESCRIPTION
## Summary
- Toasts could get buried under stacked dialogs: the toast container's popover was only promoted to the browser's top layer once, at creation time, so any `showModal()` dialog opened afterward stacked above it permanently.
- Now re-promotes the popover (`hidePopover()` + `showPopover()`) on every `Toast.show()` call, so a toast always jumps back to the top of the top-layer stack, above any number of open dialogs.

#### Note
Build/compile the JS after pulling this — `libs/toast.js` is a source file that needs to go through the JS build step for the change to take effect in the served bundle. Use `npm run build`

## Test plan
- [x] Open two (or more) stacked dialogs and trigger a toast — confirm it renders above all of them, not just the topmost.
- [x] Confirm single-dialog case still works as before.