### PR TITLE
Data recovery + mass-share fix + home/preview copy tweaks

### DIFF
--- a/templates/pages/home/home.html
+++ b/templates/pages/home/home.html
@@ -42,7 +42,7 @@
           <div class="flex flex-col">
             <span class="text-xl font-bold">{% translate "Your buildings" %}</span>
             <p class="text-sm font-normal text-[var(--text--sub-600)]">
-              {% translate "Add your buildings to access for low carbon" %}
+              {% translate "Add your buildings to assess their whole-life carbon." %}
             </p>
           </div>
           <div class="flex items-center gap-2 flex-1 justify-end">

--- a/templates/pages/home/home.html
+++ b/templates/pages/home/home.html
@@ -80,8 +80,8 @@
               hx-indicator="#buildings-loading-spinner"
               hx-include="[name='search']"
             >
-              <option value="date_desc" {% if sort_query == "date_desc" or not sort_query %}selected{% endif %}>{% translate "Date created (newest first)" %}</option>
-              <option value="date_asc" {% if sort_query == "date_asc" %}selected{% endif %}>{% translate "Date created (oldest first)" %}</option>
+              <option value="date_desc" {% if sort_query == "date_desc" or not sort_query %}selected{% endif %}>{% translate "Newest first" %}</option>
+              <option value="date_asc" {% if sort_query == "date_asc" %}selected{% endif %}>{% translate "Oldest first" %}</option>
               <option value="name_asc" {% if sort_query == "name_asc" %}selected{% endif %}>{% translate "Name (A-Z)" %}</option>
               <option value="name_desc" {% if sort_query == "name_desc" %}selected{% endif %}>{% translate "Name (Z-A)" %}</option>
             </select>


### PR DESCRIPTION
Follow-up PR to #586. Contains one **action-required** item (a data-restore command) plus small display tweaks.

---

## 🚑 1. Restore command for lost structural assemblies (REVIEW + RUN on qa)

**Incident:** six buildings owned by `expert@greenbuildingpartner.com` lost most/all of their structural assemblies on the live DB. Investigated via a local-backbone-vs-prod diff:

- Every building is **prod ≤ local** (0 buildings have more on prod), and only **7** diverge — **6 are this one account**, plus 1 trivial single-assembly diff on another user. **No broader/other-user data loss** (prod empty-building ratio 30% ≈ local 30%).
- The deployed example seed/clone is **exonerated**: on prod its 148 example assemblies share **0** with any user building, and it produced the correct 8 examples. The loss came from earlier hands-on experimentation on that one account, **not** the shipped feature.

**Fix:** `pages/management/commands/restore_lost_assemblies.py` + bundled pre-loss definitions `pages/data/restore_lost_assemblies.json` (from the local backbone; structural data only, **no PII**). It re-creates only the missing assemblies:

- **Additive only** — never deletes/edits; survivors already on the target (matched by name per building) are left untouched (no duplicates, nothing overwritten).
- **Idempotent** — re-running only adds what's still missing.
- **Validated** — a product is created only if its EPD id exists on the target DB; classifications linked only if present, else null (no broken FKs).
- **Transactional** + `--dry-run`.

**How to run (on qa):**
```bash
# preview — writes nothing; expect +45 assemblies / 50 products, 0 EPDs missing
heroku run python manage.py restore_lost_assemblies --dry-run -a <qa-app>
# then apply
heroku run python manage.py restore_lost_assemblies -a <qa-app>
```
Expected additions: Rumah Sederhana T36 +19, Building X +15, Rumah Sederhana Kita +4, Rumah Sederhana +4, Prototype 36 sqm +2, Gedung A +1. Reversible (additive; undo = delete the newly-created rows). Only these 6 buildings are touched; all other live data is untouched.

---

## 🔧 2. Fix corrupted share-of-mass/volume percentages (REVIEW + RUN on qa)

**Root cause:** for mass/volume assemblies the structural importer assigns `input_unit=PERCENT` ("share of mass/volume") but stored the source spreadsheet's **raw quantity**, not a 0–100 share. Shares summed to thousands of percent (e.g. a single material at 372,116%), failed the "shares must sum to 100%" check, and those materials were **silently skipped from the carbon calc**. **653 assemblies / 1,866 products across 213 buildings** were affected. The material's real amount is `assembly_quantity × share`, so the share is only the split ratio — normalising to 100% is the correct, ratio-preserving repair.

**Fix:**
- `import_building.import_structural_components` now **normalises** share-of-mass/volume on import (each value ÷ Σ × 100, rounded to 2 dp with the residual absorbed into the largest share so the total is exactly 100.00) — prevents recurrence.
- New `manage.py normalize_mass_shares` repairs existing corrupted assemblies the same way — additive-safe (only percent rows), **idempotent** (skips assemblies already at 100%), transactional, `--dry-run`.

**Run on qa (after restore, since restore adds assemblies that also need normalising — but it's idempotent, so order is not critical):**
```bash
heroku run python manage.py normalize_mass_shares --dry-run -a <qa-app>   # preview count
heroku run python manage.py normalize_mass_shares -a <qa-app>             # apply
```
Verified on local: 653 assemblies normalised, re-run reports 0 remaining, and a formerly-broken building now computes embodied carbon with 0 calculation errors (its share-of-mass materials were previously skipped).

---

## 3. Small display tweaks (home + example preview)

- Home subtitle: "Add your buildings to access for low carbon" → **"Add your buildings to assess their whole-life carbon."**
- Sort dropdown: "Date created (newest first)/(oldest first)" → **"Newest first" / "Oldest first"** (values unchanged; sorting identical).
- Example-preview structural table: classification shown as just the group name (e.g. **"Finishes"** instead of "120 - Finishes"); units in standard notation (**m² / m³ / kg / m / pcs / t**). Display-only — shared helpers untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
