### PR TITLE
Hotfix: restore_lost_assemblies crash (Assembly has no classification field)

### DIFF
--- a/pages/management/commands/restore_lost_assemblies.py
+++ b/pages/management/commands/restore_lost_assemblies.py
@@ -89,8 +89,7 @@ class Command(BaseCommand):
                         prod_here += len(valid_products)
                         continue
 
-                    cls_id = a["classification_id"] if a["classification_id"] and \
-                        AssemblyCategoryTechnique.objects.filter(pk=a["classification_id"]).exists() else None
+                    # NB: classification lives on StructuralProduct, not Assembly.
                     asm = Assembly.objects.create(
                         created_by=building.created_by,
                         name=a["name"],
@@ -101,7 +100,6 @@ class Command(BaseCommand):
                         is_template=False,
                         public=False,
                         draft=False,
-                        classification_id=cls_id,
                     )
                     for p in valid_products:
                         p_cls = p["classification_id"] if p["classification_id"] and \


### PR DESCRIPTION
Hotfix for the `restore_lost_assemblies` command merged in #588 — it crashed when run on beat-qa.

## The error
```
TypeError: Assembly() got unexpected keyword arguments: 'classification_id'
```

## Cause
`classification` is a field on **`StructuralProduct`**, not on **`Assembly`** — the command wrongly passed `classification_id` to `Assembly.objects.create()`. It wasn't caught before because the source buildings already had their assemblies locally, so the create path (nothing to add) never executed; on prod the assemblies are missing, so it ran and failed.

## Prod is safe
The command runs inside a single `transaction.atomic()`, so the failed run **rolled back with zero rows written** — no partial restore. Re-running after deploy is clean (the command is idempotent).

## Fix
Removed the invalid `classification_id` argument from the `Assembly` create (classification is still set on `StructuralProduct`, which has the field — one line, no other change). Verified the create path this time by deleting a building's assemblies locally in a rolled-back transaction and running the command: it recreated the assemblies + products with no error.

## Re-run on qa (after deploy)
```bash
heroku run python manage.py restore_lost_assemblies --dry-run -a beat-qa   # expect +45 assemblies / 50 products, 0 skipped
heroku run python manage.py restore_lost_assemblies -a beat-qa             # apply
```

Scope: this PR contains only the restore-command fix. (A separate share-of-mass data fix is still being validated locally and will come later.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
