### PR TITLE
docs(runbook): add the IFC-localized EPD load step (correct load command)

### DIFF
--- a/docs/production_deployment_runbook.md
+++ b/docs/production_deployment_runbook.md
@@ -21,6 +21,7 @@ step is deliberate. Read §0 and §1 before starting.
 | E | Generic structural EPD refresh (GWP/PENRT, steel→tonne) | `load_local_epds -f generic_EPDs` |
 | F | Generic operational EF update (TH electricity 0.475, natural gas) | `load_local_epds -f generic_operationaL_EPDs` |
 | G | Centralized categorization (shared resolver) | code only (used by C–F) |
+| H | IFC grid-localized generic EPDs (98 materials × ID/VN/KH/TH: binders, aluminium, glass, tiles…) | `load_local_epds -f IFC_localized_generic_EPDs` |
 
 **In-use safety:** C and D never modify EPDs already used in a building (copy-on-change).
 E and F update in place **by design** (generic placeholders) — verified during dev that
@@ -93,6 +94,12 @@ heroku run python manage.py load_local_epds -f generic_EPDs --app <your-app>
 
 # F — generic operational EPDs (electricity/natural-gas + names; needs 0049 applied)
 heroku run python manage.py load_local_epds -f generic_operationaL_EPDs --app <your-app>
+
+# H — IFC grid-localized generic EPDs (the ~216 new localized rows for ID/VN/KH/TH).
+#     NOTE: the loader is invoked through load_local_epds with the -f key below — there is
+#     NO standalone `import_ifc_localized_epds` manage.py command (that is an internal
+#     importer function). Idempotent: update_or_create keyed on (name, country, source).
+heroku run python manage.py load_local_epds -f IFC_localized_generic_EPDs --app <your-app>
 
 # G — GCCA A–G concrete Low Carbon Ratings (dynamic; run AFTER C so the Thai ready-mix
 #     concretes exist). --overwrite recomputes ALL m³ concrete labels from the formula,


### PR DESCRIPTION
### What
Adds the **IFC grid-localized generic EPD** load step (step **H**) to `docs/production_deployment_runbook.md` — the summary table and the ordered §5 load section.

### Why
The runbook documented loaders C–G but **omitted the IFC-localized loader**, so there was no correct command to deploy the ~216 localized EPDs (ID/VN/KH/TH). The name that had been passed around — `import_ifc_localized_epds` — is an **internal importer function, not a manage.py command**, so Django rejects it:

```
Unknown command: 'import_ifc_localized_epds'. Did you mean load_local_epds?
```

### Correct command (now in the runbook)
```
python manage.py load_local_epds -f IFC_localized_generic_EPDs
```
- Loads only the IFC grid-localized generic EPDs (98 materials × 4 countries).
- **Idempotent** — `update_or_create` keyed on (name, country, source); safe to run / re-run.

### Diff / alignment
- **1 file changed:** `docs/production_deployment_runbook.md` (docs only — no code/behavior change).
- rohit-qa is otherwise identical to qa (PR #590 already merged); this is the only outstanding commit.
- The loader wiring it references already exists on qa: `load_local_epds.py` key `IFC_localized_generic_EPDs`, `import_ifc_localized_epds.py`, and `pages/data/generic_epds_ifc_localized.csv`.

Supersedes the incorrect command text that was in the (now-closed) PR #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)