### PR TITLE
feat(classify): keyword fallback for free-text BOQ assembly names

### DIFF
--- a/pages/management/commands/assign_missing_classifications.py
+++ b/pages/management/commands/assign_missing_classifications.py
@@ -60,6 +60,27 @@ _NAME_TO_TAG = {
 }
 
 
+# Keyword fallback for free-text BOQ names that don't exactly match a key above.
+# Checked ONLY after exact match misses. First hit wins, so order = priority
+# (most specific first). Classification is display-only (does NOT affect carbon),
+# so a best-effort keyword tag is strictly better than leaving "No category".
+# Deliberately conservative: obvious test rows ("Test", "Hello World", "????")
+# match nothing and stay skipped rather than being mis-assigned.
+_KEYWORD_RULES = [
+    ("roof", "060"),                                             # 060 Roof
+    ("railing", "140"), ("balustrade", "140"), ("handrail", "140"),  # 140 Misc
+    ("white wash", "120"), ("whitewash", "120"), ("paint", "120"),   # 120 Finishes
+    ("plaster", "120"), ("render", "120"), ("mortar", "120"),
+    ("ceramic", "120"), ("tile", "120"), ("floor finish", "120"),
+    ("gypsum", "120"), ("screed", "120"),
+    ("floor construction", "040"),                              # 040 Beams & Slabs
+    ("weld mesh", "040"), ("reinforc", "040"), ("rebar", "040"),
+    ("lintel", "040"), ("concrete", "040"), ("rcc", "040"),
+    ("m20", "040"), ("m25", "040"), ("m30", "040"),
+    ("slab", "040"), ("beam", "040"), ("column", "040"),
+]
+
+
 def _tag_for(assembly_name, epd_name):
     name = (assembly_name or "").strip().lower()
     if name == "openings":
@@ -69,7 +90,13 @@ def _tag_for(assembly_name, epd_name):
         if "door" in e or "plywood" in e:
             return "110"
         return "140"
-    return _NAME_TO_TAG.get(name)
+    tag = _NAME_TO_TAG.get(name)
+    if tag is not None:
+        return tag
+    for kw, kw_tag in _KEYWORD_RULES:      # keyword fallback (substring, priority order)
+        if kw in name:
+            return kw_tag
+    return None
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
### What
Adds a **keyword fallback** to `assign_missing_classifications` so free-text BOQ assembly names that don't exactly match the mapping table still get a sensible category instead of staying **"No category."**

### Why
On beat-qa the command reported **39 products skipped (24 distinct names)**. Those split cleanly into:
- **Real materials** that should classify — `Infill with M20 conc`, `COncrete for lintels`, `Concrete for Lintels - M25`, `Weld mesh - 3mm`, `ceramic floor`, `Roof Structure`, `31 SS railing`, `White wash`, `27 cement mortar 1:3`, `Intermediate Floor Construction (+ plaster)`, gypsum infills…
- **Test rows / typos** — `Test`, `Hello World`, `Thailand`, `????`, `boq`, `BoQ test case`, `Reinformene tfor load bearing`.

The classifier previously did **exact-name match only**, so all of the above were skipped.

### Change
A substring keyword table (`_KEYWORD_RULES`), checked **only after** exact match misses, priority-ordered (roof → railing → finishes → beams/slabs). Verified against the exact 24 skipped names:

- **23 of 39** products now classify (concrete/lintel/mesh/reinforcement → 040 Beams & Slabs; plaster/mortar/ceramic/whitewash/gypsum → 120 Finishes; railing → 140 Misc; roof → 060 Roof).
- **16 stay skipped** — all genuine junk/typos. Nothing is force-guessed.

### Safety
- Classification is **display-only** (does **not** affect the carbon number).
- Still **null-only** (never overwrites), **idempotent**, **transactional**, `--dry-run` safe. `manage.py check` clean.
- **Action for developer:** after merge, re-run `python manage.py assign_missing_classifications` on beat-qa to pick up the 23 newly-mappable rows.

### Alignment
- Branch is off **qa**; single file changed (`assign_missing_classifications.py`, +28/−1).
- Independent of the docs-only PR #591 (runbook step H) — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)